### PR TITLE
Fix TS definition for extractRawSelector

### DIFF
--- a/lib/purgecss.d.ts
+++ b/lib/purgecss.d.ts
@@ -16,8 +16,8 @@ declare class Purgecss {
     extractors?: Array<Purgecss.ExtractorsObj>
   ): Set<string>
   extractRawSelector(
-    content: Array<RawContent>,
-    extractors?: Array<ExtractorsObj>
+    content: Array<Purgecss.RawContent>,
+    extractors?: Array<Purgecss.ExtractorsObj>
   ): Set<string>
   getFileExtractor(
     filename: string,


### PR DESCRIPTION
## Proposed changes

RawContent and ExtractorsObj exist under the Purgecss namespace.
They were referenced correctly everywhere except in the extractRawSelector definition.

Without it, using the raw selector would result in the following Typescript error:

```shell
node_modules/purgecss/lib/purgecss.d.ts(19,20): error TS2304: Cannot find name 'RawContent'.

19     content: Array<RawContent>,

node_modules/purgecss/lib/purgecss.d.ts(20,24): error TS2304: Cannot find name 'ExtractorsObj'.

20     extractors?: Array<ExtractorsObj>
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
