### PR TITLE
Expose 'raw' option for css in types

### DIFF
--- a/flow-typed/index.js
+++ b/flow-typed/index.js
@@ -7,7 +7,7 @@ type RawContent = {
 
 declare type Options = {
   content: Array<string | RawContent>,
-  css: Array<string>,
+  css: Array<string | RawContent>,
   extractors?: Array<ExtractorsObj>,
   whitelist?: Array<string>,
   whitelistPatterns?: Array<RegExp>,

--- a/lib/purgecss.d.ts
+++ b/lib/purgecss.d.ts
@@ -36,7 +36,7 @@ declare class Purgecss {
 declare namespace Purgecss {
   export interface Options {
     content: Array<string | RawContent>
-    css: Array<string>
+    css: Array<string | RawContent>
     extractors?: Array<ExtractorsObj>
     whitelist?: Array<string>
     whitelistPatterns?: Array<RegExp>


### PR DESCRIPTION
Hello again! I thought to split this into a separate one, in case there is any iteration needed.

## Proposed changes
The code and tests show that it is possible to specify a 'raw' option for css:
```js
    css: [
      {
        raw: style,
        extension: 'css' // Technically not needed; see below
      }
    ],
```

Existing code segment with functionality:
https://github.com/FullHuman/purgecss/blob/148e2db8a8aeb6293e9bd5cd51277b56d099daee/src/index.js#L124

Test using it:
https://github.com/FullHuman/purgecss/blob/master/__tests__/purgecssDefault.test.js#L323

However, **the type interface does not expose it as an option**. Thus, if you're using Typescript or Flow and try to use the raw option for css, an error is raised:
```shell
  Type '{ content: { raw: string; extension: string; }[]; css: { raw: string; extension: string; }[]; ext...' is not assignable to type 'Options'.
    Types of property 'css' are incompatible.
      Type '{ raw: string; extension: string; }[]' is not assignable to type 'string[]'.
        Type '{ raw: string; extension: string; }' is not assignable to type 'string'.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [~] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

NOTE:
I went with `RawContent` as the option for consistency with the `content` interface. This type is technically true, but the `extension` field is not used by the code (since it would be css anyway); this is seen in https://github.com/FullHuman/purgecss/blob/148e2db8a8aeb6293e9bd5cd51277b56d099daee/src/index.js#L124
I can change it to an explicit type if needed:

```flow
type RawCss = {
  raw: string
}
```

For that matter, I have also not touched the code. Changing the `cssOptions: Array<any>` in `getCssContents` would pair well:

```flow
getCssContents(cssOptions: Array<string | RawCss>, cssSelectors: Set<string>): Array<ResultPurge> {

// Or

getCssContents(cssOptions: Array<string | RawContent>, cssSelectors: Set<string>): Array<ResultPurge> {
```

None of these changes would be breaking.

Let me know if any of these alternatives sound better, and I'll get to them :)