### PR TITLE
Don't delete keyframe animations with floats

### DIFF
--- a/__tests__/purgecssDefault.test.js
+++ b/__tests__/purgecssDefault.test.js
@@ -308,6 +308,36 @@ describe('purge methods with files and default extractor', () => {
             expect(purgecssResult.includes(`src: url('xxx')`)).toBe(false)
         })
     })
+
+    describe('keep keyframe decimals', () => {
+        let purgecssResult
+        beforeAll(() => {
+            purgecssResult = new Purgecss({
+                content: [
+                    {
+                        raw: '<div class="xx"></div>',
+                        extension: 'html'
+                    }
+                ],
+                css: [
+                    {
+                        raw: `
+                    @keyframes xxx {
+                        0% {opacity: 0;}
+                        99.9% {opacity: 1;}
+                    }
+                    .xx { animation: xxx 200ms linear both }
+                    `
+                    }
+                ],
+                keyframes: false
+            }).purge()[0].css
+            // console.log(purgecssResult)
+        })
+        it('keeps `99.9%`', () => {
+            expect(purgecssResult.includes('99.9%')).toBe(true)
+        })
+    })
 })
 
 describe('purge methods with raw content and default extractor', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -283,7 +283,8 @@ class Purgecss {
                     for (const { type, value } of selector.nodes) {
                         if (
                             SELECTOR_STANDARD_TYPES.includes(type) &&
-                            typeof value !== 'undefined'
+                            typeof value !== 'undefined' &&
+                            /^\d/g.test(value) === false
                         ) {
                             selectorsInRule.push(value)
                         } else if (


### PR DESCRIPTION
## Proposed changes

fixes Issue: https://github.com/FullHuman/purgecss/issues/64
PostCSS thinks that the .9 from 99.9% is a css class selector, this selector then gets treated as any other by purgeCSS but when it finds no selector for .9 its removed.
In this PR the class selector is only treated as a selector if it does not start with a number (^\d)

A side effect is that all other class selectors that start with a number will be kept, but since classes that start with a integer are illegal in CSS this should not be a problem


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)