### PR TITLE
Update readme for Vue CLI 3

### DIFF
--- a/examples/with-vue/README.md
+++ b/examples/with-vue/README.md
@@ -1,39 +1,38 @@
-# with-vue-webpack
+# with Vue CLI 3
 
 > A Vue.js project
 
 ## Created with vue-cli
 
-This example shows how to set up Purgecss with vue-webpack template.\
-Once you initialized your project with `vue init webpack`, install the webpack plugin
-for purgecss:
+This example shows how to set up Purgecss with a newly create Vue CLI 3 app.
+Once you initialized your project with `vue create app-name`, install the webpack plugin for purgecss and path:
 
 ```
-npm i --save-dev glob-all purgecss-webpack-plugin
+npm i --save-dev glob-all purgecss-webpack-plugin path
 ```
 
-You need to modify the file `webpack.prod.conf.js` by adding the following code:
+Based on the options you chose, you project may or may not have a vue.config.js file in the root directory.
+If it doesn't exist, create it with the following content:
 
-line 13
-
-```js
-// import Purgecss webpack plugin and glob-all
-const PurgecssPlugin = require('purgecss-webpack-plugin')
-const glob = require('glob-all')
 ```
+const PurgecssPlugin = require('purgecss-webpack-plugin');
+const glob = require('glob-all');
+const path = require('path');
 
-line 58
-
-```js
-    // Remove unused CSS using purgecss. See https://github.com/FullHuman/purgecss
-    // for more information about purgecss.
-    new PurgecssPlugin({
-      paths: glob.sync([
-        path.join(__dirname, './../src/index.html'),
-        path.join(__dirname, './../**/*.vue'),
-        path.join(__dirname, './../src/**/*.js')
-      ])
-    }),
+module.exports = {
+  configureWebpack: {
+    // Merged into the final Webpack config
+    plugins: [
+      new PurgecssPlugin({
+        paths: glob.sync([
+          path.join(__dirname, './src/index.html'),
+          path.join(__dirname, './**/*.vue'),
+          path.join(__dirname, './src/**/*.js')
+        ])
+      })
+    ]
+  }
+}
 ```
 
 ## Results


### PR DESCRIPTION
With the change to Vue CLI 3 the vue documentation no longer works.
To update users need to import path in addition to
purgecss-webpack-plugin and then set vue.config.js as shown in the
commit.

After testing a repo with Bootstrap added and no classes called, the
file size reduction is nearly the same as what is referenced in the
original ~3.4kb

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Purgecss?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
