### PR TITLE
fix #100

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,8 +250,6 @@ class Purgecss {
         arraySelector.forEach(selector => {
             selectors.add(selector)
         })
-        // Remove empty string
-        selectors.delete('')
         return selectors
     }
 


### PR DESCRIPTION
PurgeCSS is likely to be used with a minifier anyway, so no need to remove empty strings, which cause bugs such as #100.