### PR TITLE
Fix issue #166

### DIFF
--- a/__tests__/purgecss.test.js
+++ b/__tests__/purgecss.test.js
@@ -350,6 +350,10 @@ describe('keyframes', () => {
     it('removes flash', () => {
         expect(purgecssResult.includes('@keyframes flash')).toBe(false)
     })
+    it('keeps keyframes from animations with multiple keyframes', () => {
+        expect(purgecssResult.includes('@keyframes scale')).toBe(true)
+        expect(purgecssResult.includes('@keyframes spin')).toBe(true)
+    })
 })
 
 describe('pseudo selectors', () => {

--- a/__tests__/test_examples/keyframes/keyframes.css
+++ b/__tests__/test_examples/keyframes/keyframes.css
@@ -25,3 +25,27 @@
 .flash {
     animation: flash
 }
+
+@keyframes scale {
+    from {
+        transform: scale(1);
+    }
+
+    to {
+        transform: scale(2);
+    }
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.scale-spin {
+    animation: spin 300ms linear infinite forwards,scale 300ms linear infinite alternate;
+}

--- a/__tests__/test_examples/keyframes/keyframes.html
+++ b/__tests__/test_examples/keyframes/keyframes.html
@@ -1,2 +1,5 @@
 <div class="bounce">
 </div>
+
+<div class="scale-spin">
+</div>

--- a/src/index.js
+++ b/src/index.js
@@ -327,7 +327,7 @@ class Purgecss {
             for (const { prop, value } of node.nodes) {
                 if (this.options.keyframes) {
                     if (prop === 'animation' || prop === 'animation-name') {
-                        for (const word of value.split(' ')) {
+                        for (const word of value.split(/[\s,]+/)) {
                             this.usedAnimations.add(word)
                         }
                     }


### PR DESCRIPTION
## Proposed changes
I am changing the separtor for the words inside the animation prop from spaces to spaces and comas. So that something like `spin 300ms linear infinite forwards,scale 300ms linear infinite alternate` becomes
```js
[  "spin", "300ms", "linear", "infinite", "forwards", "scale", "300ms", "linear", "infinite", "alternate" ]
```
rather than
```js
[  "spin", "300ms", "linear", "infinite", "forwards,scale", "300ms", "linear", "infinite", "alternate" ]
```

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
