### PR TITLE
rework issue #149 to avoid 'Cannot read property 'extract' of undefined'

### DIFF
--- a/__tests__/purgecss.test.js
+++ b/__tests__/purgecss.test.js
@@ -495,6 +495,7 @@ describe('rejected', () => {
         }).purge()[0]
         expect(purgecssResult.rejected).toEqual([
             '.parent1 p',
+            '.parent1 h1',
             '.parent1.d22222ef',
             '.parent1.d222222222222222222ef',
             '.parent.def1',

--- a/__tests__/purgecssDefault.test.js
+++ b/__tests__/purgecssDefault.test.js
@@ -11,6 +11,21 @@ describe('purge methods with files and default extractor', () => {
         expect(received.includes('.ui.grid')).toBe(true)
     })
 
+    it('uses default extractor if no other extractor matches', () => {
+        const purgeCss = new Purgecss({
+            content: ['./__tests__/test_examples/attribute_selector/attribute_selector.html'],
+            css: ['./__tests__/test_examples/attribute_selector/attribute_selector.css'],
+            extractors: [
+                {
+                    extractor: undefined,
+                    extensions: ['never_heard_of_please_use_default']
+                }
+            ]
+        })
+        const received = purgeCss.purge()[0].css
+        expect(received.includes('.ui.grid')).toBe(true)
+    })
+
     describe('purges correctly (find intact classes) with default extractor', () => {
         let purgecssResult
         beforeAll(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ class Purgecss {
         if (typeof options === 'string' || typeof options === 'undefined')
             options = this.loadConfigFile(options)
         this.checkOptions(options)
-        this.options = Object.assign(defaultOptions, options)
+        this.options = Object.assign({}, defaultOptions, options)
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ class Purgecss {
 
         const extractorObj = extractors.find(extractor =>
             extractor.extensions.find(ext => filename.endsWith(ext))
-        ) || DefaultExtractor
+        ) || { extractor: DefaultExtractor }
         return extractorObj.extractor
     }
 


### PR DESCRIPTION
## Proposed changes

The change for #149 prepares the DefaultExtractor as a default, but in the next line only the property "extractor" is returned. For the new default this will be undefined, leading to the error 

     TypeError: Cannot read property 'extract' of undefined

Due to this the new default is not usable, a workaround is to keep (like in the previous version) the default extractor in the configuration.

## Types of changes

What types of changes does your code introduce to Purgecss?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
This is WIP as a test is still missing

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

./.
