### PR TITLE
Add support for overriding the default extractor

### DIFF
--- a/__tests__/purgecss.test.js
+++ b/__tests__/purgecss.test.js
@@ -339,6 +339,42 @@ describe('special characters, with custom Extractor as a function', () => {
     })
 })
 
+describe('special characters, overriding the default Extractor', () => {
+    let purgecssResult
+    class CustomExtractor {
+        static extract(content) {
+            return content.match(/[A-z0-9-:/]+/g)
+        }
+    }
+
+    beforeAll(() => {
+        purgecssResult = new Purgecss({
+            content: [`${root}special_characters/special_characters.js`],
+            css: [`${root}special_characters/special_characters.css`],
+            defaultExtractor: CustomExtractor
+        }).purge()[0].css
+    })
+
+    it('finds tailwind class', () => {
+        expect(purgecssResult.includes('md\\:w-1\\/3')).toBe(true)
+    })
+})
+
+describe('special characters, overriding the default Extractor with a function', () => {
+    let purgecssResult
+    beforeAll(() => {
+        purgecssResult = new Purgecss({
+            content: [`${root}special_characters/special_characters.js`],
+            css: [`${root}special_characters/special_characters.css`],
+            defaultExtractor: content => content.match(/[A-z0-9-:/]+/g),
+        }).purge()[0].css
+    })
+
+    it('finds tailwind class', () => {
+        expect(purgecssResult.includes('md\\:w-1\\/3')).toBe(true)
+    })
+})
+
 describe('nth-child', () => {
     let purgecssResult
     beforeAll(() => {

--- a/flow-typed/index.js
+++ b/flow-typed/index.js
@@ -8,6 +8,7 @@ type RawContent = {
 declare type Options = {
   content: Array<string | RawContent>,
   css: Array<string | RawContent>,
+  defaultExtractor?: Object,
   extractors?: Array<ExtractorsObj>,
   whitelist?: Array<string>,
   whitelistPatterns?: Array<RegExp>,

--- a/lib/purgecss.es.js
+++ b/lib/purgecss.es.js
@@ -303,10 +303,28 @@ var substr = 'ab'.substr(-1) === 'b' ? function (str, start, len) {
   return str.substr(start, len);
 };
 
+var DefaultExtractor =
+/*#__PURE__*/
+function () {
+  function DefaultExtractor() {
+    _classCallCheck(this, DefaultExtractor);
+  }
+
+  _createClass(DefaultExtractor, null, [{
+    key: "extract",
+    value: function extract(content) {
+      return content.match(/[A-Za-z0-9_-]+/g) || [];
+    }
+  }]);
+
+  return DefaultExtractor;
+}();
+
 //      
 var defaultOptions = {
   css: [],
   content: [],
+  defaultExtractor: DefaultExtractor,
   extractors: [],
   whitelist: [],
   output: undefined,
@@ -335,23 +353,6 @@ var ERROR_STDOUT_TYPE = 'Error Type option stdout: expected a boolean';
 var CSS_WHITELIST = ['*', '::-webkit-scrollbar', '::selection', ':root', '::before', '::after'];
 
 var SELECTOR_STANDARD_TYPES = ['class', 'id', 'universal', 'pseudo'];
-
-var DefaultExtractor =
-/*#__PURE__*/
-function () {
-  function DefaultExtractor() {
-    _classCallCheck(this, DefaultExtractor);
-  }
-
-  _createClass(DefaultExtractor, null, [{
-    key: "extract",
-    value: function extract(content) {
-      return content.match(/[A-Za-z0-9_-]+/g) || [];
-    }
-  }]);
-
-  return DefaultExtractor;
-}();
 
 var Purgecss =
 /*#__PURE__*/
@@ -698,13 +699,13 @@ function () {
     key: "getFileExtractor",
     value: function getFileExtractor(filename) {
       var extractors = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
-      if (!extractors.length) return DefaultExtractor;
+      if (!extractors.length) return this.options.defaultExtractor;
       var extractorObj = extractors.find(function (extractor) {
         return extractor.extensions.find(function (ext) {
           return filename.endsWith(ext);
         });
       }) || {
-        extractor: DefaultExtractor
+        extractor: this.options.defaultExtractor
       };
       return extractorObj.extractor;
     }

--- a/lib/purgecss.js
+++ b/lib/purgecss.js
@@ -307,10 +307,28 @@ var substr = 'ab'.substr(-1) === 'b' ? function (str, start, len) {
   return str.substr(start, len);
 };
 
+var DefaultExtractor =
+/*#__PURE__*/
+function () {
+  function DefaultExtractor() {
+    _classCallCheck(this, DefaultExtractor);
+  }
+
+  _createClass(DefaultExtractor, null, [{
+    key: "extract",
+    value: function extract(content) {
+      return content.match(/[A-Za-z0-9_-]+/g) || [];
+    }
+  }]);
+
+  return DefaultExtractor;
+}();
+
 //      
 var defaultOptions = {
   css: [],
   content: [],
+  defaultExtractor: DefaultExtractor,
   extractors: [],
   whitelist: [],
   output: undefined,
@@ -339,23 +357,6 @@ var ERROR_STDOUT_TYPE = 'Error Type option stdout: expected a boolean';
 var CSS_WHITELIST = ['*', '::-webkit-scrollbar', '::selection', ':root', '::before', '::after'];
 
 var SELECTOR_STANDARD_TYPES = ['class', 'id', 'universal', 'pseudo'];
-
-var DefaultExtractor =
-/*#__PURE__*/
-function () {
-  function DefaultExtractor() {
-    _classCallCheck(this, DefaultExtractor);
-  }
-
-  _createClass(DefaultExtractor, null, [{
-    key: "extract",
-    value: function extract(content) {
-      return content.match(/[A-Za-z0-9_-]+/g) || [];
-    }
-  }]);
-
-  return DefaultExtractor;
-}();
 
 var Purgecss =
 /*#__PURE__*/
@@ -702,13 +703,13 @@ function () {
     key: "getFileExtractor",
     value: function getFileExtractor(filename) {
       var extractors = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
-      if (!extractors.length) return DefaultExtractor;
+      if (!extractors.length) return this.options.defaultExtractor;
       var extractorObj = extractors.find(function (extractor) {
         return extractor.extensions.find(function (ext) {
           return filename.endsWith(ext);
         });
       }) || {
-        extractor: DefaultExtractor
+        extractor: this.options.defaultExtractor
       };
       return extractorObj.extractor;
     }

--- a/src/constants/defaultOptions.js
+++ b/src/constants/defaultOptions.js
@@ -1,8 +1,11 @@
 // @flow
 
+import DefaultExtractor from '../Extractors/DefaultExtractor'
+
 const defaultOptions: Options = {
     css: [],
     content: [],
+    defaultExtractor: DefaultExtractor,
     extractors: [],
     whitelist: [],
     output: undefined,

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,6 @@ import {
 import CSS_WHITELIST from './constants/cssWhitelist'
 import SELECTOR_STANDARD_TYPES from './constants/selectorTypes'
 
-import DefaultExtractor from './Extractors/DefaultExtractor'
-
 class Purgecss {
     options: Options
     root: Object
@@ -228,11 +226,11 @@ class Purgecss {
      * @param {array} extractors Array of extractors definition objects
      */
     getFileExtractor(filename: string, extractors: Array<ExtractorsObj> = []) {
-        if (!extractors.length) return DefaultExtractor
+        if (!extractors.length) return this.options.defaultExtractor
 
         const extractorObj = extractors.find(extractor =>
             extractor.extensions.find(ext => filename.endsWith(ext))
-        ) || { extractor: DefaultExtractor }
+        ) || { extractor: this.options.defaultExtractor }
         return extractorObj.extractor
     }
 


### PR DESCRIPTION
## Proposed changes

This PR implements the ability override the default extractor as proposed in #180.

It allows the user to set the default extractor using a new `defaultExtractor` option that accepts either a class or a function:

```js
// Using a class
new Purgecss({
    content: [`${root}special_characters/special_characters.js`],
    css: [`${root}special_characters/special_characters.css`],
    defaultExtractor: class {
        static extract(content) {
            return content.match(/[A-z0-9-:/]+/g)
        }
    }
})

// Using a function
new Purgecss({
    content: [`${root}special_characters/special_characters.js`],
    css: [`${root}special_characters/special_characters.css`],
    defaultExtractor: content => content.match(/[A-z0-9-:/]+/g),
})
```

This simplifies configuration if the end user wants to use a custom extractor for everything, as they don't have to provide a list of matching extensions. It also helps to avoid issues where the user wants to use a custom extractor for everything, but forgets to update the extension list after introducing a new file type to the project. Since Purgecss is often only run in production builds, this can help reduce end-user mistakes that cause bugs in production that weren't detected in development.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

