### PR TITLE
Windows config path fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class Purgecss {
         const pathConfig = typeof configFile === 'undefined' ? CONFIG_FILENAME : configFile
         let options
         try {
-            const t = path.resolve(process.cwd(), pathConfig).replace(/\\/g, '/')
+            const t = path.join(process.cwd(), pathConfig)
             options = require(t)
         } catch (e) {
             throw new Error(ERROR_CONFIG_FILE_LOADING + e.message)

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class Purgecss {
         const pathConfig = typeof configFile === 'undefined' ? CONFIG_FILENAME : configFile
         let options
         try {
-            const t = path.resolve(process.cwd(), pathConfig)
+            const t = path.resolve(process.cwd(), pathConfig).replace(/\\/g, '/')
             options = require(t)
         } catch (e) {
             throw new Error(ERROR_CONFIG_FILE_LOADING + e.message)


### PR DESCRIPTION
## Proposed changes
Currently using path.resolve on windows results in invalid paths. Replaced path.resolve with path.join.

#137 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
