### PR TITLE
Allow CLI options to override config file

### DIFF
--- a/bin/purgecss
+++ b/bin/purgecss
@@ -42,22 +42,37 @@ yargsBin = yargs
     .alias("v", "version")
 argv = yargs.argv
 
-options = {
-    content: argv.content,
-    css: argv.css,
-    whitelist: argv.whitelist
-}
 
 var purgecss;
-if ((typeof argv.config === "undefined") && (typeof argv.css === "undefined" || typeof argv.content === "undefined")) {
-    yargsBin.showHelp("log")
-    return
-}
-if (argv.config) {
-    purgecss = new Purgecss(argv.config)
+var configObj;
+
+
+if (typeof argv.config === "undefined") {
+    if (typeof argv.css === "undefined" || typeof argv.content === "undefined") {
+        yargsBin.showHelp("log")
+        return
+    }
+    configObj = {
+        content: argv.content,
+        css: argv.css,
+        whitelist: argv.whitelist
+    }
 } else {
-    purgecss = new Purgecss(options)
+    const t = path.join(process.cwd(), argv.config)
+    configObj = require(t);
+    if (typeof argv.css !== "undefined") {
+        configObj.css = argv.css
+    }
+    if (typeof argv.content !== "undefined") {
+        configObj.content = argv.content
+    }
+    if (typeof argv.whitelist !== "undefined") {
+        configObj.whitelist = argv.whitelist
+    }
 }
+
+
+purgecss = new Purgecss(configObj)
 
 if (argv.out) {
     var result = purgecss.purge()


### PR DESCRIPTION
Currently, if a config file is given to the CLI, all other options are
ignored.

With this change, the config file is read first and then the other
options are used to override the config file settings.


## Proposed changes

This implements the feature request for issue #227.

__note__: I did not make it load a config file by default. Since there are things in the config file that cannot be overriden, I felt that adding that functionality would require the addition of a new option to _stop_ the loading of the default file. Otherwise, you would have no way back to the current behavior.

## Types of changes

What types of changes does your code introduce to Purgecss?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)