### PR TITLE
Fix typo to output file

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -60,12 +60,12 @@ You can use the CLI with a [configuration file](configuration.md). Use `--config
 purgecss --config ./purgecss.config.js
 ```
 
-### --out
+### --output
 
 By default, the CLI outputs the result in the console. If you wish to return the CSS as files, specify the directory to write the purified CSS files to.
 
 ```text
-purgecss --css css/app.css --content src/index.html src/**/*.js --out build/css/
+purgecss --css css/app.css --content src/index.html src/**/*.js --output build/css/
 ```
 
 ### --whitelist


### PR DESCRIPTION
It's not `--out` it's `--output`

Should fix https://github.com/mhanberg/jekyll-purgecss/issues/7 & https://github.com/FullHuman/purgecss/issues/262 because I guess they checked the readme and see the `--out` option.