### PR TITLE
Fix output option typo

### DIFF
--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -47,7 +47,7 @@ Add the following code in **package.json**
 
 ```json
 "scripts": {
-  "postbuild": "purgecss --css build/static/css/*.css --content build/static/index.html build/static/js/*.js --out build/static/css"
+  "postbuild": "purgecss --css build/static/css/*.css --content build/static/index.html build/static/js/*.js --output build/static/css"
 },
 ```
 


### PR DESCRIPTION
One more typo on the `--output` option in the React doc.

Related: #266