### PR TITLE
feat(whitelist): allow setting a detailed whitelist

### DIFF
--- a/packages/postcss-purgecss/src/index.ts
+++ b/packages/postcss-purgecss/src/index.ts
@@ -1,17 +1,17 @@
 import postcss from "postcss";
-import PurgeCSS, { defaultOptions, mergeExtractorSelectors } from "purgecss";
+import PurgeCSS, { mergeExtractorSelectors, parseUserOptions } from "purgecss";
 
 import { RawContent, UserDefinedOptions } from "./types";
 
-const purgeCSSPlugin = postcss.plugin<Omit<UserDefinedOptions, "css">>(
+type PostCssUserDefinedOptions = Omit<UserDefinedOptions, "css">;
+
+const purgeCSSPlugin = postcss.plugin<PostCssUserDefinedOptions>(
   "postcss-plugin-purgecss",
   function(opts) {
     return async function(root, result) {
       const purgeCSS = new PurgeCSS();
-      const options = {
-        ...defaultOptions,
-        ...opts
-      };
+      const options = parseUserOptions<PostCssUserDefinedOptions>(opts);
+
       purgeCSS.options = options;
 
       const { content, extractors } = options;

--- a/packages/purgecss/__tests__/whitelist-detailed.test.ts
+++ b/packages/purgecss/__tests__/whitelist-detailed.test.ts
@@ -1,0 +1,96 @@
+import PurgeCSS from "./../src/index";
+
+const root = "./packages/purgecss/__tests__/test_examples/";
+
+describe("whitelist-detailed", () => {
+  let purgedCSS: string = "";
+  beforeAll(async done => {
+    const resultsPurge = await new PurgeCSS().purge({
+      content: [`${root}whitelist/whitelist.html`],
+      css: [`${root}whitelist/whitelist.css`],
+      whitelist: {
+        classes: ["random"],
+        tags: ["button", "h1"],
+        ids: ["yep"]
+      },
+      whitelistPatterns: {
+        attributes: { names: [/data-v-.*/] },
+        classes: [/nav-/]
+      }
+    });
+    purgedCSS = resultsPurge[0].css;
+    done();
+  });
+
+  it("finds attr", () => {
+    expect(purgedCSS.includes("[data-v-test]")).toBe(true);
+  });
+
+  it("finds random class", () => {
+    expect(purgedCSS.includes(".random")).toBe(true);
+  });
+
+  it("finds h1", () => {
+    expect(purgedCSS.includes("h1")).toBe(true);
+  });
+
+  it("finds #yep", () => {
+    expect(purgedCSS.includes("#yep")).toBe(true);
+  });
+
+  it("finds button", () => {
+    expect(purgedCSS.includes("button")).toBe(true);
+  });
+
+  it("finds .nav-blue", () => {
+    expect(purgedCSS.includes(".nav-blue")).toBe(true);
+  });
+
+  it("finds .nav-red", () => {
+    expect(purgedCSS.includes(".nav-red")).toBe(true);
+  });
+});
+
+describe("whitelistPatternsChildren", () => {
+  let purgedCSS: string;
+  beforeAll(async () => {
+    const resultsPurge = await new PurgeCSS().purge({
+      content: [
+        `${root}whitelist_patterns_children/whitelist_patterns_children.html`
+      ],
+      css: [
+        `${root}whitelist_patterns_children/whitelist_patterns_children.css`
+      ],
+      whitelistPatternsChildren: [/^card$/]
+    });
+    purgedCSS = resultsPurge[0].css;
+  });
+
+  it("finds card class", () => {
+    expect(purgedCSS.includes(".card")).toBe(true);
+  });
+
+  it("finds card--title", () => {
+    expect(purgedCSS.includes(".title")).toBe(false);
+  });
+
+  it("finds card--content", () => {
+    expect(purgedCSS.includes(".card .content")).toBe(true);
+  });
+
+  it("finds btn", () => {
+    expect(purgedCSS.includes(".btn")).toBe(true);
+  });
+
+  it("finds btn yellow", () => {
+    expect(purgedCSS.includes(".card .btn .yellow")).toBe(true);
+  });
+
+  it("finds btn red", () => {
+    expect(purgedCSS.includes(".btn .red")).toBe(false);
+  });
+
+  it("excludes btn--green", () => {
+    expect(purgedCSS.includes(".btn__green")).toBe(false);
+  });
+});

--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import glob from "glob";
 import path from "path";
 
-import { defaultOptions } from "./options";
+import {defaultOptions, emptyWhitelist} from "./options";
 export { defaultOptions } from "./options";
 
 import {
@@ -162,17 +162,6 @@ export function mergeExtractorSelectors(
   };
 }
 
-const emptyWhitelist = {
-  attributes: {
-    names: [],
-    values: []
-  },
-  classes: [],
-  ids: [],
-  tags: [],
-  undetermined: []
-};
-
 export function transformWhiteList<T = string>(
   whitelist?: T[] | Partial<WhiteListDetailed<T>>
 ): WhiteListDetailed<T> {
@@ -180,13 +169,6 @@ export function transformWhiteList<T = string>(
     ...emptyWhitelist,
     ...(Array.isArray(whitelist) || !whitelist
       ? {
-          attributes: {
-            names: [],
-            values: []
-          },
-          classes: [],
-          ids: [],
-          tags: [],
           undetermined: whitelist ? [...whitelist] : []
         }
       : {

--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import glob from "glob";
 import path from "path";
 
-import {defaultOptions, emptyWhitelist} from "./options";
+import { defaultOptions, emptyWhitelist } from "./options";
 export { defaultOptions } from "./options";
 
 import {
@@ -174,8 +174,8 @@ export function transformWhiteList<T = string>(
       : {
           ...whitelist,
           attributes: {
-            names: (whitelist.attributes && whitelist.attributes.names) || [],
-            values: (whitelist.attributes && whitelist.attributes.values) || []
+            names: whitelist.attributes?.names || [],
+            values: whitelist.attributes?.values || []
           }
         })
   };
@@ -654,45 +654,37 @@ class PurgeCSS {
 
         whitelists.push({
           type: "string",
-          list:
-            this.options.whitelist && this.options.whitelist.attributes.names,
+          list: this.options.whitelist?.attributes?.names,
           test: nodeSelector.attribute
         });
 
         whitelists.push({
           type: "string",
-          list:
-            this.options.whitelist && this.options.whitelist.attributes.values,
+          list: this.options.whitelist?.attributes?.values,
           test: nodeSelector.value!
         });
 
         whitelists.push({
           type: "string",
-          list: this.options.whitelist && this.options.whitelist.undetermined,
+          list: this.options.whitelist?.undetermined,
           test: nodeSelector.attribute
         });
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.attributes.names,
+          list: this.options.whitelistPatterns?.attributes?.names,
           test: nodeSelector.attribute
         });
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.attributes.values,
+          list: this.options.whitelistPatterns?.attributes?.values,
           test: nodeSelector.value!
         });
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.undetermined,
+          list: this.options.whitelistPatterns?.undetermined,
           test: nodeSelector.attribute
         });
 
@@ -707,29 +699,25 @@ class PurgeCSS {
 
         whitelists.push({
           type: "string",
-          list: this.options.whitelist && this.options.whitelist.classes,
+          list: this.options.whitelist?.classes,
           test: nodeSelector.value
         });
 
         whitelists.push({
           type: "string",
-          list: this.options.whitelist && this.options.whitelist.undetermined,
+          list: this.options.whitelist?.undetermined,
           test: nodeSelector.value
         });
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.classes,
+          list: this.options.whitelistPatterns?.classes,
           test: nodeSelector.value
         });
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.undetermined,
+          list: this.options.whitelistPatterns?.undetermined,
           test: nodeSelector.value
         });
         break;
@@ -742,13 +730,13 @@ class PurgeCSS {
 
         whitelists.push({
           type: "string",
-          list: this.options.whitelist && this.options.whitelist.ids,
+          list: this.options.whitelist?.ids,
           test: nodeSelector.value
         });
 
         whitelists.push({
           type: "string",
-          list: this.options.whitelist && this.options.whitelist.undetermined,
+          list: this.options.whitelist?.undetermined,
           test: nodeSelector.value
         });
 
@@ -762,9 +750,7 @@ class PurgeCSS {
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.undetermined,
+          list: this.options.whitelistPatterns?.undetermined,
           test: nodeSelector.value
         });
         break;
@@ -777,29 +763,25 @@ class PurgeCSS {
 
         whitelists.push({
           type: "string",
-          list: this.options.whitelist && this.options.whitelist.tags,
+          list: this.options.whitelist?.tags,
           test: nodeSelector.value
         });
 
         whitelists.push({
           type: "string",
-          list: this.options.whitelist && this.options.whitelist.undetermined,
+          list: this.options.whitelist?.undetermined,
           test: nodeSelector.value
         });
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.tags,
+          list: this.options.whitelistPatterns?.tags,
           test: nodeSelector.value
         });
 
         whitelists.push({
           type: "pattern",
-          list:
-            this.options.whitelistPatterns &&
-            this.options.whitelistPatterns.undetermined,
+          list: this.options.whitelistPatterns?.undetermined,
           test: nodeSelector.value
         });
         break;
@@ -813,15 +795,13 @@ class PurgeCSS {
 
           whitelists.push({
             type: "string",
-            list: this.options.whitelist && this.options.whitelist.undetermined,
+            list: this.options.whitelist?.undetermined,
             test: nodeSelector.value
           });
 
           whitelists.push({
             type: "pattern",
-            list:
-              this.options.whitelistPatterns &&
-              this.options.whitelistPatterns.undetermined,
+            list: this.options.whitelistPatterns?.undetermined,
             test: nodeSelector.value
           });
         }
@@ -852,23 +832,17 @@ class PurgeCSS {
     switch (nodeSelector.type) {
       case "attribute":
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.attributes.names,
+          list: this.options.whitelistPatternsChildren?.attributes?.names,
           test: nodeSelector.attribute
         });
 
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.attributes.values,
+          list: this.options.whitelistPatternsChildren?.attributes?.values,
           test: nodeSelector.value!
         });
 
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.undetermined,
+          list: this.options.whitelistPatternsChildren?.undetermined,
           test: nodeSelector.attribute
         });
 
@@ -876,55 +850,41 @@ class PurgeCSS {
         break;
       case "class":
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.classes,
+          list: this.options.whitelistPatternsChildren?.classes,
           test: nodeSelector.value
         });
 
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.undetermined,
+          list: this.options.whitelistPatternsChildren?.undetermined,
           test: nodeSelector.value
         });
         break;
       case "id":
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.ids,
+          list: this.options.whitelistPatternsChildren?.ids,
           test: nodeSelector.value
         });
 
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.undetermined,
+          list: this.options.whitelistPatternsChildren?.undetermined,
           test: nodeSelector.value
         });
         break;
       case "tag":
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.tags,
+          list: this.options.whitelistPatternsChildren?.tags,
           test: nodeSelector.value
         });
 
         whitelists.push({
-          list:
-            this.options.whitelistPatternsChildren &&
-            this.options.whitelistPatternsChildren.undetermined,
+          list: this.options.whitelistPatternsChildren?.undetermined,
           test: nodeSelector.value
         });
         break;
       default:
         if (nodeSelector.value) {
           whitelists.push({
-            list:
-              this.options.whitelistPatternsChildren &&
-              this.options.whitelistPatternsChildren.undetermined,
+            list: this.options.whitelistPatternsChildren?.undetermined,
             test: nodeSelector.value
           });
         }

--- a/packages/purgecss/src/options.ts
+++ b/packages/purgecss/src/options.ts
@@ -1,5 +1,16 @@
 import { Options, ExtractorResult } from "./types/";
 
+export const emptyWhitelist = {
+  attributes: {
+    names: [],
+    values: []
+  },
+  classes: [],
+  ids: [],
+  tags: [],
+  undetermined: []
+};
+
 export const defaultOptions: Options = {
   css: [],
   content: [],
@@ -12,34 +23,7 @@ export const defaultOptions: Options = {
   stdin: false,
   stdout: false,
   variables: false,
-  whitelist: {
-    attributes: {
-      names: [],
-      values: []
-    },
-    classes: [],
-    ids: [],
-    tags: [],
-    undetermined: []
-  },
-  whitelistPatterns: {
-    attributes: {
-      names: [],
-      values: []
-    },
-    classes: [],
-    ids: [],
-    tags: [],
-    undetermined: []
-  },
-  whitelistPatternsChildren: {
-    attributes: {
-      names: [],
-      values: []
-    },
-    classes: [],
-    ids: [],
-    tags: [],
-    undetermined: []
-  }
+  whitelist: {...emptyWhitelist},
+  whitelistPatterns: {...emptyWhitelist},
+  whitelistPatternsChildren: {...emptyWhitelist}
 };

--- a/packages/purgecss/src/options.ts
+++ b/packages/purgecss/src/options.ts
@@ -12,7 +12,34 @@ export const defaultOptions: Options = {
   stdin: false,
   stdout: false,
   variables: false,
-  whitelist: [],
-  whitelistPatterns: [],
-  whitelistPatternsChildren: []
+  whitelist: {
+    attributes: {
+      names: [],
+      values: []
+    },
+    classes: [],
+    ids: [],
+    tags: [],
+    undetermined: []
+  },
+  whitelistPatterns: {
+    attributes: {
+      names: [],
+      values: []
+    },
+    classes: [],
+    ids: [],
+    tags: [],
+    undetermined: []
+  },
+  whitelistPatternsChildren: {
+    attributes: {
+      names: [],
+      values: []
+    },
+    classes: [],
+    ids: [],
+    tags: [],
+    undetermined: []
+  }
 };

--- a/packages/purgecss/src/types/index.ts
+++ b/packages/purgecss/src/types/index.ts
@@ -18,16 +18,25 @@ export interface RawCSS {
   raw: string;
 }
 
-export interface ExtractorResultDetailed {
+interface GenericFilter<T = string> {
   attributes: {
-    names: string[];
-    values: string[];
+    names: T[];
+    values: T[];
   };
-  classes: string[];
-  ids: string[];
-  tags: string[];
-  undetermined: string[];
+  classes: T[];
+  ids: T[];
+  tags: T[];
+  undetermined: T[];
 }
+
+export type ExtractorResultDetailed = GenericFilter;
+
+export type WhiteListDetailed<T> = Omit<GenericFilter<T>, "attributes"> & {
+  attributes: {
+    names?: T[];
+    values?: T[];
+  };
+};
 
 export type ExtractorResult = ExtractorResultDetailed | string[];
 
@@ -52,9 +61,11 @@ export interface UserDefinedOptions {
   stdin?: boolean;
   stdout?: boolean;
   variables?: boolean;
-  whitelist?: string[];
-  whitelistPatterns?: Array<RegExp>;
-  whitelistPatternsChildren?: Array<RegExp>;
+  whitelist?: string[] | Partial<WhiteListDetailed<string>>;
+  whitelistPatterns?: Array<RegExp> | Partial<WhiteListDetailed<RegExp>>;
+  whitelistPatternsChildren?:
+    | Array<RegExp>
+    | Partial<WhiteListDetailed<RegExp>>;
 }
 
 export interface Options {
@@ -69,9 +80,9 @@ export interface Options {
   stdin: boolean;
   stdout: boolean;
   variables: boolean;
-  whitelist: string[];
-  whitelistPatterns: Array<RegExp>;
-  whitelistPatternsChildren: Array<RegExp>;
+  whitelist: WhiteListDetailed<string>;
+  whitelistPatterns: WhiteListDetailed<RegExp>;
+  whitelistPatternsChildren: WhiteListDetailed<RegExp>;
 }
 
 export interface ResultPurge {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "outDir": "dist",
     "sourceMap": false,
-    "target": "esnext",
+    "target": "es2018",
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
an initial draft for detailed whitelist setting, fully backwards compatible.
see whitelist-detailed.test.ts for an example

still to clarify is how we handle attributes.values within the whitelist.

target of tsconfig changed from esnext to es2018 to support optional chaning and other new typescript features :)

all the implementations have still the old UserDefinedOptions becasue they have their own interfaces, not quite sure what's the reason behind this, therefore I left it untouched for the first iteration. My suggestion would be to use the same type defintions from "purgecss" (base) and extend it to their needs.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
