### PR TITLE
feat(content-options): add option contentFunction to be able to decla…

### DIFF
--- a/packages/postcss-purgecss/README.md
+++ b/packages/postcss-purgecss/README.md
@@ -33,10 +33,26 @@ See [PostCSS] docs for examples for your environment.
 All of the options of purgecss are available to use with the plugins.
 You will find below the main options available. For the complete list, go to the [purgecss documentation website](https://www.purgecss.com/configuration.html#options).
 
-### `content` (**required**)
-Type: `string | Object`
+### `content` (**required** or use `contentFunction` instead)
+Type: `Array<string>`
 
 You can specify content that should be analyzed by Purgecss with an array of filenames or globs. The files can be HTML, Pug, Blade, etc.
+
+### `contentFunction` (as alternative to `content`)
+Type: `(sourceInputFile: string) => Array<string>`
+
+The function receives the current source input file. With this you may provide a specific array of globs for each input. E.g. for 
+an angular application only scan the components template counterpart for every component scss file:
+
+```js
+purgecss({
+  contentFunction: (source: string) => {
+    (/component\.scss$/.test(source))
+      ? [sourceInputFile.replace(/scss$/, 'html')]
+      : ['./src/**/*.html']
+  },
+})
+```
 
 ### `extractors`
 Type: `Array<Object>`

--- a/packages/postcss-purgecss/__tests__/index.test.ts
+++ b/packages/postcss-purgecss/__tests__/index.test.ts
@@ -7,7 +7,7 @@ describe("Purgecss postcss plugin", () => {
   const files = ["simple", "font-keyframes"];
 
   for (const file of files) {
-    it(`remove unused css successfully: ${file}`, done => {
+    it(`remove unused css with content option successfully: ${file}`, done => {
       const input = fs
         .readFileSync(`${__dirname}/fixtures/src/${file}/${file}.css`)
         .toString();
@@ -25,6 +25,38 @@ describe("Purgecss postcss plugin", () => {
         .then((result: any) => {
           expect(result.css).toBe(expected);
           expect(result.warnings().length).toBe(0);
+          done();
+        });
+    });
+  }
+
+  for (const file of files) {
+    it(`remove unused css with contentFunction option successfully: ${file}`, done => {
+      const input = fs
+        .readFileSync(`${__dirname}/fixtures/src/${file}/${file}.css`)
+        .toString();
+      const expected = fs
+        .readFileSync(`${__dirname}/fixtures/expected/${file}.css`)
+        .toString();
+
+      const sourceFileName = `src/${file}/${file}.css`;
+      const contentFunction = jest
+        .fn()
+        .mockReturnValue([`${__dirname}/fixtures/src/${file}/${file}.html`]);
+
+      postcss([
+        purgeCSSPlugin({
+          contentFunction,
+          fontFace: true,
+          keyframes: true
+        })
+      ])
+        .process(input, { from: sourceFileName })
+        .then((result: any) => {
+          expect(result.css).toBe(expected);
+          expect(result.warnings().length).toBe(0);
+          expect(contentFunction).toHaveBeenCalledTimes(1);
+          expect(contentFunction.mock.calls[0][0]).toContain(sourceFileName);
           done();
         });
     });

--- a/packages/postcss-purgecss/src/index.ts
+++ b/packages/postcss-purgecss/src/index.ts
@@ -12,6 +12,13 @@ const purgeCSSPlugin = postcss.plugin<Omit<UserDefinedOptions, "css">>(
         ...defaultOptions,
         ...opts
       };
+
+      if (opts && typeof opts.contentFunction === "function") {
+        options.content = opts.contentFunction(
+          (root.source && root.source.input.file) || ""
+        );
+      }
+
       purgeCSS.options = options;
 
       const { content, extractors } = options;

--- a/packages/postcss-purgecss/src/types/index.ts
+++ b/packages/postcss-purgecss/src/types/index.ts
@@ -11,7 +11,8 @@ export interface Extractors {
   extractor: ExtractorFunction;
 }
 export interface UserDefinedOptions {
-  content: Array<string | RawContent>;
+  content?: Array<string | RawContent>;
+  contentFunction?: (sourceFile: string) => Array<string | RawContent>;
   css: Array<string | RawCSS>;
   defaultExtractor?: ExtractorFunction;
   extractors?: Array<Extractors>;


### PR DESCRIPTION
fixes https://github.com/FullHuman/purgecss/issues/278

Adds new option to `postcss-purgecss`:

### `contentFunction` (as alternative to `content`)
Type: `(sourceInputFile: string) => Array<string>`

The function receives the current source input file. With this you may provide a specific array of globs for each input. E.g. for 
an angular application only scan the components template counterpart for every component scss file:

```js
purgecss({
  contentFunction: (source: string) => {
    (/component\.scss$/.test(source))
      ? [sourceInputFile.replace(/scss$/, 'html')]
      : ['./src/**/*.html']
  },
})
```

I didn't overload the `content` option as it felt wrong it being also used as is in purgecss itself.