### PR TITLE
Fixed contentFunction code example in postcss-purgecss plugin readme

### DIFF
--- a/packages/postcss-purgecss/README.md
+++ b/packages/postcss-purgecss/README.md
@@ -46,10 +46,11 @@ an angular application only scan the components template counterpart for every c
 
 ```js
 purgecss({
-  contentFunction: (source: string) => {
-    (/component\.scss$/.test(source))
-      ? [sourceInputFile.replace(/scss$/, 'html')]
-      : ['./src/**/*.html']
+  contentFunction: (sourceInputFileName: string) => {
+    if (/component\.scss$/.test(sourceInputFileName))
+      return [sourceInputFileName.replace(/scss$/, 'html')]
+    else
+      return ['./src/**/*.html']
   },
 })
 ```


### PR DESCRIPTION
Code example for `contentFunction` was an arrow function that had braces but no return statement, so it didn't do anything, plus it used two variable names, which made things even more confusing.
I've change it to use if block with return statement because I think it is more readable. Also adjusted variable name.

btw: 
when will this be published?
current version doesn't have this code, I really like the idea and I'd like to use it :)