### PR TITLE
Feat: Added option to postcss plugin to register content files as dependencies in webpack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,11 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.yml]
-indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ interface UserDefinedOptions {
   fontFace?: boolean
   keyframes?: boolean
   output?: string
+  registerDependencies?: boolean
   rejected?: boolean
   stdin?: boolean
   stdout?: boolean
@@ -212,6 +213,33 @@ await new PurgeCSS().purge({
   content: ['index.html', '**/*.js', '**/*.html', '**/*.vue'],
   css: ['css/app.css'],
   rejected: true
+})
+```
+
+- **registerDependencies \(default: false\)**
+
+Some time you may want PurgeCSS to be enabled in development mode, if so then you want it to purge css correctly your css based on updated source content. In order for this to work we need to register all the content files that you specify in content globs as dependencies to webpack. This will inform webpack that when you change content source your css needs to be processed again since the class list may have been updated.
+
+To enable this behaviour just set `registerDependencies` option to `true`;
+
+__Keep in mind__ that if you just specify a very broad glob pattern in `content` option then all that source will have to be scanned and processed for every css entry point, that can be quite expensive and wasteful. Use `contentFunction` to provide a more granular information about what css entry is dependent on what content source files.
+
+```js
+await new PurgeCSS().purge({
+  contentFunction: (styleSource) => {
+    if (/component\.scss$/.test(styleSource)) {
+      // if style source is a part of component then
+      // it's dependent content is it's component template and code
+      return [
+        styleSource.replace(/scss$/, 'html'),
+        styleSource.replace(/scss$/, 'js')
+      ]
+    } else {
+      return ['./src/**/*.html']
+    }
+  },
+  css: ['css/app.css'],
+  registerDependencies: true
 })
 ```
 

--- a/packages/postcss-purgecss/README.md
+++ b/packages/postcss-purgecss/README.md
@@ -41,7 +41,7 @@ You can specify content that should be analyzed by Purgecss with an array of fil
 ### `contentFunction` (as alternative to `content`)
 Type: `(sourceInputFile: string) => Array<string>`
 
-The function receives the current source input file. With this you may provide a specific array of globs for each input. E.g. for 
+The function receives the current source input file. With this you may provide a specific array of globs for each input. E.g. for
 an angular application only scan the components template counterpart for every component scss file:
 
 ```js
@@ -73,6 +73,14 @@ You can whitelist selectors based on a regular expression with whitelistPatterns
 ### `rejected`
 Type: `boolean`
 Default value: `false`
+
+### `registerDependencies`
+Type: `boolean`
+Default value: `false`
+
+If true, all files that are found by content globs or returned from content function will be registered as dependencies for webpack through PostCSS messages.
+More information and examples [here](https://purgecss.com/configuration.html#options).
+
 
 If true, purged selectors will be captured and rendered as PostCSS messages.
 Use with a PostCSS reporter plugin like [`postcss-reporter`](https://github.com/postcss/postcss-reporter)

--- a/packages/postcss-purgecss/__tests__/index.test.ts
+++ b/packages/postcss-purgecss/__tests__/index.test.ts
@@ -32,18 +32,18 @@ describe("Purgecss postcss plugin", () => {
   }
 
   for (const file of files) {
-    it(`remove unused css with contentFunction option successfully: ${file}`, done => {
-      const input = fs
-        .readFileSync(`${__dirname}/fixtures/src/${file}/${file}.css`)
-        .toString();
-      const expected = fs
-        .readFileSync(`${__dirname}/fixtures/expected/${file}.css`)
-        .toString();
+    const sourceFileName = `src/${file}/${file}.css`;
+    const contentFileName = `src/${file}/${file}.html`;
+    const sourceFilePath = path.resolve(sourceFileName);
+    const inputFilePath = path.resolve(__dirname, "fixtures", sourceFileName);
+    const contentFilePath = path.resolve(__dirname, "fixtures", contentFileName);
+    const expectedFilePath = path.resolve(__dirname, `fixtures/expected/${file}.css`);
 
-      const sourceFileName = `src/${file}/${file}.css`;
-      const contentFunction = jest
-        .fn()
-        .mockReturnValue([`${__dirname}/fixtures/src/${file}/${file}.html`]);
+    const input = fs.readFileSync(inputFilePath).toString();
+    const expected = fs.readFileSync(expectedFilePath).toString();
+
+    it(`remove unused css with contentFunction option successfully: ${file}`, done => {
+      const contentFunction = jest.fn().mockReturnValue([contentFilePath]);
 
       postcss([
         purgeCSSPlugin({
@@ -58,19 +58,12 @@ describe("Purgecss postcss plugin", () => {
           expect(result.warnings().length).toBe(0);
           expect(contentFunction).toHaveBeenCalledTimes(1);
           expect(contentFunction.mock.calls[0][0]).toContain(sourceFileName);
+          expect(contentFunction.mock.results[0].value[0]).toBe(contentFilePath);
           done();
         });
     });
 
-    it(`register content files as dependencies in webpack: ${file}`, done => {
-      const sourceFileName = `src/${file}/${file}.css`;
-      const contentFileName = `src/${file}/${file}.html`;
-      const inputFilePath = path.resolve(__dirname, "fixtures", sourceFileName);
-      const contentFilePath = path.resolve(__dirname, "fixtures", contentFileName);
-
-      const input = fs.readFileSync(inputFilePath).toString();
-
-      const sourceFilePath = path.resolve(sourceFileName);
+    it(`register content files as dependencies in webpack if flag is set: ${file}`, done => {
       const contentFunction = jest.fn().mockReturnValue([contentFilePath]);
 
       postcss([
@@ -90,6 +83,24 @@ describe("Purgecss postcss plugin", () => {
             file: contentFilePath,
             parent: sourceFilePath
           });
+          done();
+        });
+    });
+
+    it(`not register content files as dependencies in webpack if flag is not set: ${file}`, done => {
+      const contentFunction = jest.fn().mockReturnValue([contentFilePath]);
+
+      postcss([
+        purgeCSSPlugin({
+          contentFunction,
+          fontFace: true,
+          keyframes: true,
+          registerDependencies: false
+        })
+      ])
+        .process(input, {from: sourceFileName})
+        .then((result: any) => {
+          expect(result.messages.length).toBe(0);
           done();
         });
     });

--- a/packages/postcss-purgecss/src/index.ts
+++ b/packages/postcss-purgecss/src/index.ts
@@ -46,7 +46,7 @@ const purgeCSSPlugin = postcss.plugin<Omit<UserDefinedOptions, "css">>(
         cssRawSelectors
       );
 
-      if (fileDependencies && fileDependencies.length) {
+      if (opts?.registerDependencies && fileDependencies && fileDependencies.length) {
         fileDependencies.forEach(file => {
           result.messages.push({
             type: "dependency",

--- a/packages/postcss-purgecss/src/index.ts
+++ b/packages/postcss-purgecss/src/index.ts
@@ -46,7 +46,7 @@ const purgeCSSPlugin = postcss.plugin<Omit<UserDefinedOptions, "css">>(
         cssRawSelectors
       );
 
-      if (opts?.registerDependencies && fileDependencies && fileDependencies.length) {
+      if (opts && opts.registerDependencies && fileDependencies && fileDependencies.length) {
         fileDependencies.forEach(file => {
           result.messages.push({
             type: "dependency",

--- a/packages/postcss-purgecss/src/types/index.ts
+++ b/packages/postcss-purgecss/src/types/index.ts
@@ -19,6 +19,7 @@ export interface UserDefinedOptions {
   fontFace?: boolean;
   keyframes?: boolean;
   output?: string;
+  registerDependencies?: boolean;
   rejected?: boolean;
   stdin?: boolean;
   stdout?: boolean;


### PR DESCRIPTION
## Proposed changes

I've added an option to postcss plugin to register content files as dependencies in webpack. This allows to regenerate class list when source is changed which makes PurgeCSS usable in development mode.

I made this because I had a few cases when due to specifics of the project setup I needed purgecss to be enabled in development mode, but the problem was that it analyzes content and generated class list once, so consequent changes of source didn't result in updated css output.

The flag is called `registerDependencies` and is set to false by default. The reason is that it adds some delay to the webpack devserver hot module reload if you specify a very broad content glob patterns. In order to optimize it you need to leverage new `contentFunction` option to inform plugin about what style source is dependent on what files. This way it doesn't affect current default behavior in any way.

To allow this I also had to change `extractSelectorsFromFiles` function in purgecss source to return not just list of classes but also a list of files from which those classes where extracted, that list is then used to generate dependency messages.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I haven't figured out how to do this for a webpack plugin module. Maybe this can be a thing for maintainers to add at some point if it makes sense.
