### PR TITLE
Documentation: Update api documentation to show commonjs option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,8 +22,18 @@ In the following examples, the options passed to PurgeCSS are the same as the on
 
 ## Usage
 
+### ES Module Import Syntax
 ```javascript
 import PurgeCSS from 'purgecss'
+const purgeCSSResult = await new PurgeCSS().purge({
+  content: ['**/*.html'],
+  css: ['**/*.css']
+})
+```
+
+### CommonJS Syntax
+```javascript
+const { PurgeCSS } = require('purgecss')
 const purgeCSSResult = await new PurgeCSS().purge({
   content: ['**/*.html'],
   css: ['**/*.css']


### PR DESCRIPTION
## Proposed changes

Documentation update to show CommonJS code along side the ES module code, for those upgrading from PurgeCSS v1 to v2.

The change from v1 to v2 introduces ES modules, which is still experimental in Node.js, and is only supported without a flag in Node.js 13, so not widely used in Node yet.

For those upgrading to v2 of PurgeCSS from v1 using CommonJS, they need to either destructure the { PurgeCSS } class from the require statement or use `.default` after the require to import the default export of the PurgeCSS class.

in Purge CSS v1 this used to work

```
const PurgeCSS = require('purgecss')
```

for it to work with CommonJS in v2 it needs to be changed to this

```
const { PurgeCSS } = require('purgecss')
```

or this

```
const PurgeCSS = require('purgecss').default
```

if you don't make this change from v1 to v2 you'll get a 'TypeError: PurgeCSS is not a constructor` error, as the PurgeCSS class is not properly imported.

The docs change is just to show how PurgeCSS should be imported when using CommonJS, so those upgrading can see what is required.


## Types of changes

N/A - Docs update

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

N/A - Docs update

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Documentation Change
