### PR TITLE
Improve performance of PurgeCSS extractor result merging

### DIFF
--- a/packages/purgecss/__tests__/performance.test.ts
+++ b/packages/purgecss/__tests__/performance.test.ts
@@ -1,0 +1,30 @@
+import PurgeCSS from "../src/index";
+
+describe("performance", () => {
+  it("should not suffer from tons of content and css", function () {
+    // TODO Remove this excessive timeout once performance is better.
+    jest.setTimeout(60000);
+    const start = Date.now();
+    return new PurgeCSS()
+      .purge({
+        // Use all of the .js files in node_modules to purge all of the .css
+        // files in __tests__/test_examples, including tailwind.css, which is
+        // a whopping 908KB of CSS before purging.
+        content: ["./packages/purgecss/node_modules/**/*.js"],
+        css: [
+          "./packages/purgecss/__tests__/test_examples/*/*.css",
+          "./packages/purgecss/node_modules/tailwindcss/dist/tailwind.css",
+        ],
+      })
+      .then((results) => {
+        expect(results.length).toBeGreaterThanOrEqual(1);
+        expect(
+          results.some((result) => {
+            return result.file && result.file.endsWith("/tailwind.css");
+          })
+        ).toBe(true);
+        results.forEach((result) => expect(typeof result.css).toBe("string"));
+        console.log("performance test took", Date.now() - start, "ms");
+      });
+  });
+});

--- a/packages/purgecss/__tests__/performance.test.ts
+++ b/packages/purgecss/__tests__/performance.test.ts
@@ -2,8 +2,6 @@ import PurgeCSS from "../src/index";
 
 describe("performance", () => {
   it("should not suffer from tons of content and css", function () {
-    // TODO Remove this excessive timeout once performance is better.
-    jest.setTimeout(60000);
     const start = Date.now();
     return new PurgeCSS()
       .purge({

--- a/packages/purgecss/package.json
+++ b/packages/purgecss/package.json
@@ -45,7 +45,8 @@
     "postcss-selector-parser": "^6.0.2"
   },
   "devDependencies": {
-    "@types/glob": "^7.1.1"
+    "@types/glob": "^7.1.1",
+    "tailwindcss": "^1.2.0"
   },
   "bugs": {
     "url": "https://github.com/FullHuman/purgecss/issues"

--- a/packages/purgecss/src/types/index.ts
+++ b/packages/purgecss/src/types/index.ts
@@ -29,6 +29,96 @@ export interface ExtractorResultDetailed {
   undetermined: string[];
 }
 
+function mergeSets(into: Set<string>, from?: string[] | Set<string>) {
+  if (from) {
+    from.forEach(into.add, into);
+  }
+}
+
+export class ExtractorResultSets {
+  private undetermined = new Set<string>();
+  private attrNames = new Set<string>();
+  private attrValues = new Set<string>();
+  private classes = new Set<string>();
+  private ids = new Set<string>();
+  private tags = new Set<string>();
+
+  constructor(er: ExtractorResult) {
+    this.merge(er);
+  }
+
+  merge(that: ExtractorResult | ExtractorResultSets) {
+    if (Array.isArray(that)) {
+      mergeSets(this.undetermined, that);
+    } else if (that instanceof ExtractorResultSets) {
+      mergeSets(this.undetermined, that.undetermined);
+      mergeSets(this.attrNames, that.attrNames);
+      mergeSets(this.attrValues, that.attrValues);
+      mergeSets(this.classes, that.classes);
+      mergeSets(this.ids, that.ids);
+      mergeSets(this.tags, that.tags);
+    } else {
+      // ExtractorResultDetailed:
+      mergeSets(this.undetermined, that.undetermined);
+      if (that.attributes) {
+        mergeSets(this.attrNames, that.attributes.names);
+        mergeSets(this.attrValues, that.attributes.values);
+      }
+      mergeSets(this.classes, that.classes);
+      mergeSets(this.ids, that.ids);
+      mergeSets(this.tags, that.tags);
+    }
+    return this;
+  }
+
+  hasAttrName(name: string): boolean {
+    return this.attrNames.has(name) || this.undetermined.has(name);
+  }
+
+  private someAttrValue(predicate: (value: string) => boolean): boolean {
+    const forEachFn = (value: string) => {
+      if (predicate(value)) throw true;
+    };
+    try {
+      // The only way to break early from a Set.prototype.forEach
+      // loop is to throw from the callback function.
+      this.attrValues.forEach(forEachFn);
+      this.undetermined.forEach(forEachFn);
+    } catch (result) {
+      return result;
+    }
+    return false;
+  }
+
+  hasAttrPrefix(prefix: string): boolean {
+    return this.someAttrValue((value) => value.startsWith(prefix));
+  }
+
+  hasAttrSuffix(suffix: string): boolean {
+    return this.someAttrValue((value) => value.endsWith(suffix));
+  }
+
+  hasAttrSubstr(substr: string): boolean {
+    return this.someAttrValue((value) => value.includes(substr));
+  }
+
+  hasAttrValue(value: string): boolean {
+    return this.attrValues.has(value) || this.undetermined.has(value);
+  }
+
+  hasClass(name: string): boolean {
+    return this.classes.has(name) || this.undetermined.has(name);
+  }
+
+  hasId(id: string): boolean {
+    return this.ids.has(id) || this.undetermined.has(id);
+  }
+
+  hasTag(tag: string): boolean {
+    return this.tags.has(tag) || this.undetermined.has(tag);
+  }
+}
+
 export type ExtractorResult = ExtractorResultDetailed | string[];
 
 export type ExtractorFunction = (content: string) => ExtractorResult;

--- a/packages/purgecss/src/types/index.ts
+++ b/packages/purgecss/src/types/index.ts
@@ -76,16 +76,11 @@ export class ExtractorResultSets {
   }
 
   private someAttrValue(predicate: (value: string) => boolean): boolean {
-    const forEachFn = (value: string) => {
-      if (predicate(value)) throw true;
-    };
-    try {
-      // The only way to break early from a Set.prototype.forEach
-      // loop is to throw from the callback function.
-      this.attrValues.forEach(forEachFn);
-      this.undetermined.forEach(forEachFn);
-    } catch (result) {
-      return result;
+    for (const val of this.attrValues) {
+      if (predicate(val)) return true;
+    }
+    for (const val of this.undetermined) {
+      if (predicate(val)) return true;
     }
     return false;
   }


### PR DESCRIPTION
## Proposed changes

### Add a performance regression test to `packages/purgecss` (fa54f1194cd35efb60ec5b517c2715cfa5573838)

This test uses all of the `.js` files in `node_modules` to purge all of the `.css` files in `__tests__/test_examples`, including the newly added [`tailwind.css`](https://tailwindcss.com/), which is a whopping 908KB of CSS (before purging).

On my machine, this all takes about 50 seconds, though it may exceed the 60sec `jest.setTimeout` when running in a CI environment. I will push additional commits that improve performance significantly.

Although this test may seem extreme, the Tailwind docs [recommend](https://tailwindcss.com/docs/controlling-file-size/#setting-up-purgecss) a PurgeCSS setup that can easily resemble (or dwarf) this test, when used in larger applications with lots of content files and lots of CSS files.

### Avoid expensive copies of `ExtractorResultDetailed` objects (5c5bcdcd83e0e0d4aa29c2f5e63aa3647f9e376c)

Should fix #300.

First, I created an `ExtractorResultSets` class as the internal representation of `ExtractorResultDetailed` input objects, so that I could make its properties private and query them with meaningful methods. This allowed me to safely change the types used to represent the internal collections of strings from `string[]` to `Set<string>`, for faster merging and lookup.

Thanks to the new `ExtractorResultSets.merge` method, which modifies its receiver object (`this`) rather than returning a new `ExtractorResultSets` object, we no longer have to call `mergeExtractorSelectors` repeatedly to create unnecessary intermediate copies of `ExtractorResultDetailed` objects.

Avoiding these expensive copies can be a big win when the `ExtractorResultSets` objects contain many (tens or hundreds of thousands of) strings, saving those `Set<string>`s from getting repeatedly copied and then discarded as garbage memory. Instead, each new `ExtractorResultSets` object gets merged into a single `ExtractorResultSets` result object, leading to a lot less copying of strings and objects and `Set`s.

> Note: the `new Set([...oldSet, ...newValues])` pattern used by `purgecss@1.x` was wasteful in a similar way to `mergeExtractorSelectors`, because it required iterating over the entire `oldSet`, then concatenating its elements with the `newValues`, then creating a completely new `Set` out of that array. Writing code in this style tends to undo the performance benefits of using a `Set`.

## Types of changes

- [x] Performance regression tests
- [x] Bugfix (#300)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)