### PR TITLE
Add Gutenberg support to purgecss-with-wordpress

### DIFF
--- a/packages/purgecss-with-wordpress/index.js
+++ b/packages/purgecss-with-wordpress/index.js
@@ -18,6 +18,7 @@ module.exports = {
     'wp-caption-text',
     'screen-reader-text',
     'comment-list',
+    'wp-social-link',
   ],
   whitelistPatterns: [
     /^search(-.*)?$/,
@@ -34,5 +35,10 @@ module.exports = {
     /^tax-(.*)?$/,
     /^term-(.*)?$/,
     /^(.*)?-?paged(-.*)?$/,
+    /^wp-block-(.*)?$/,
+    /^has-(.*)?$/,
+    /^is-(.*)?$/,
+    /^wp-embed-(.*)?$/,
+    /^blocks-gallery-(.*)?$/,
   ],
 };


### PR DESCRIPTION
Better support for WordPress' Gutenberg related block classes and style classes used by the block editor.

## Proposed changes

Added patterns for Gutenberg classes. Only specified front end classes, assuming WP devs won't be purging their custom admin themes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

No other files or packages were edited, so I didn't run tests on them. No version bump, I thought it best if you decide when to push updates out.

Core styling can be referenced in this stylesheet: https://github.com/WordPress/WordPress/blob/master/wp-includes/css/dist/block-library/style.css
