### PR TITLE
Add `whitelistPatternsGreedy` option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ interface UserDefinedOptions {
   whitelist?: string[]
   whitelistPatterns?: Array<RegExp>
   whitelistPatternsChildren?: Array<RegExp>
+  whitelistPatternsGreedy?: Array<RegExp>
 }
 
 interface RawContent {
@@ -168,7 +169,7 @@ You can learn more about extractors [here](extractors.md).
 
 - **fontFace \(default: false\)**
 
-If there are any unused @font-face rules in your css, you can remove them by setting the `fontFace` option to `true`
+If there are any unused @font-face rules in your css, you can remove them by setting the `fontFace` option to `true`.
 
 ```js
 await new PurgeCSS().purge({
@@ -192,7 +193,7 @@ await new PurgeCSS().purge({
 
 - **variables \(default: false\)**
 
-If your are using Custom Properties (CSS variables), or a library using them such as Bootstrap, you can remove unused CSS variables by setting the `variables` option to `true`.
+If you are using Custom Properties (CSS variables), or a library using them such as Bootstrap, you can remove unused CSS variables by setting the `variables` option to `true`.
 
 ```js
 await new PurgeCSS().purge({
@@ -204,8 +205,7 @@ await new PurgeCSS().purge({
 
 - **rejected \(default: false\)**
 
-It can sometimes be more practical to scan through the removed list to see if there's anything obviously wrong.
-If you want to do it, use the `rejected` option.
+It can sometimes be more practical to scan through the removed list to see if there's anything obviously wrong. If you want to do it, use the `rejected` option.
 
 ```js
 await new PurgeCSS().purge({
@@ -217,7 +217,7 @@ await new PurgeCSS().purge({
 
 - **whitelist**
 
-You can whitelist selectors to stop PurgeCSS from removing them from your CSS. This can be accomplished with the options `whitelist` and `whitelistPatterns`.
+You can whitelist selectors to stop PurgeCSS from removing them from your CSS. This can be accomplished with the options `whitelist`, `whitelistPatterns`, `whitelistPatternsChildren`, and `whitelistPatternsGreedy`.
 
 ```js
 const purgecss = await new PurgeCSS().purge({
@@ -227,7 +227,7 @@ const purgecss = await new PurgeCSS().purge({
 })
 ```
 
-In the example, the selectors `.random`, `#yep`, `button` will be left in the final CSS.
+In this example, the selectors `.random`, `#yep`, `button` will be left in the final CSS.
 
 - **whitelistPatterns**
 
@@ -241,11 +241,11 @@ const purgecss = await new PurgeCSS().purge({
 })
 ```
 
-In the example, selectors ending with `red` such as `.bg-red` will be left in the final CSS.
+In this example, selectors ending with `red` such as `.bg-red` will be left in the final CSS.
 
 - **whitelistPatternsChildren**
 
-You can whitelist selectors based on a regular expression with `whitelistPatternsChildren`. Contrary to `whitelistPatterns`, it will also whitelist children of the selectors.
+You can whitelist selectors and their children based on a regular expression with `whitelistPatternsChildren`.
 
 ```js
 const purgecss = await new PurgeCSS().purge({
@@ -255,5 +255,18 @@ const purgecss = await new PurgeCSS().purge({
 })
 ```
 
-In the example, selectors such as `red p` or `.bg-red .child-of-bg` will be left in the final CSS.
+In this example, selectors such as `.bg-red .child-of-bg` will be left in the final CSS, even if `child-of-bg` is not found.
 
+- **whitelistPatternsGreedy**
+
+Finally, you can whitelist whole selectors if any part of that selector matches a regular expression with `whitelistPatternsGreedy`.
+
+```js
+const purgecss = await new PurgeCSS().purge({
+  content: [], // content
+  css: [], // css
+  whitelistPatternsGreedy: [/red$/]
+})
+```
+
+In this example, selectors such as `button.bg-red.nonexistent-class` will be left in the final CSS, even if `button` and `nonexistent-class` are not found.

--- a/docs/plugins/webpack.md
+++ b/docs/plugins/webpack.md
@@ -121,7 +121,7 @@ new PurgecssPlugin({
 })
 ```
 
-* #### whitelist, whitelistPatterns and whitelistPatternsChildren
+* #### whitelist, whitelistPatterns, whitelistPatternsChildren, and whitelistPatternsGreedy
 
 Similar as for the `paths` option, you can also define functions for the following options:
 
@@ -141,11 +141,17 @@ function collectWhitelistPatternsChildren() {
     return [/^whitelisted-/];
 }
 
+function collectWhitelistPatternsGreedy() {
+    // do something to collect the whitelist
+    return [/^whitelisted-/];
+}
+
 // In the webpack configuration
 new PurgecssPlugin({
   whitelist: collectWhitelist,
   whitelistPatterns: collectWhitelistPatterns,
-  whitelistPatternsChildren: collectWhitelistPatternsChildren
+  whitelistPatternsChildren: collectWhitelistPatternsChildren,
+  whitelistPatternsGreedy: collectWhitelistPatternsGreedy
 })
 ```
 

--- a/docs/whitelisting.md
+++ b/docs/whitelisting.md
@@ -10,7 +10,7 @@ meta:
 
 # Whitelisting
 
-You can whitelist selectors to stop PurgeCSS from removing them from your CSS. This can be accomplished with the PurgeCSS options `whitelist`, `whitelistPatterns`, `whitelistPatternsChildren`, or directly in your CSS with a special comment.
+You can whitelist selectors to stop PurgeCSS from removing them from your CSS. This can be accomplished with the PurgeCSS options `whitelist`, `whitelistPatterns`, `whitelistPatternsChildren`, `whitelistPatternsGreedy`, or directly in your CSS with a special comment.
 
 ## Specific selectors
 
@@ -28,18 +28,19 @@ In the example, the selectors `.random`, `#yep`, `button` will be left in the fi
 
 ## Patterns
 
-You can whitelist selectors based on a regular expression with `whitelistPatterns` and `whitelistPatternsChildren`.
+You can whitelist selectors based on a regular expression with `whitelistPatterns`, `whitelistPatternsChildren`, and `whitelistPatternsGreedy`.
 
 ```javascript
 const purgecss = new Purgecss({
     content: [], // content
     css: [], // css
     whitelistPatterns: [/red$/],
-    whitelistPatternsChildren: [/blue$/]
+    whitelistPatternsChildren: [/blue$/],
+    whitelistPatternsGreedy: [/yellow$/]
 })
 ```
 
-In the example, selectors ending with `red` such as `.bg-red`, and children of selectors ending with `blue` such as `blue p` or `.bg-blue .child-of-bg`, will be left in the final CSS.
+In the example, selectors ending with `red` such as `.bg-red`, selectors ending with `blue` as well as their children such as `blue p` or `.bg-blue .child-of-bg`, and selectors that have any part ending with `yellow` such as `button.bg-yellow.other-class`, will be left in the final CSS.
 
 Patterns are regular expressions. You can use [regexr](https://regexr.com) to verify the regular expressions correspond to what you are looking for.
 

--- a/packages/gulp-purgecss/src/types/index.ts
+++ b/packages/gulp-purgecss/src/types/index.ts
@@ -24,4 +24,5 @@ export interface UserDefinedOptions {
   whitelist?: string[];
   whitelistPatterns?: Array<RegExp>;
   whitelistPatternsChildren?: Array<RegExp>;
+  whitelistPatternsGreedy?: Array<RegExp>;
 }

--- a/packages/postcss-purgecss/src/types/index.ts
+++ b/packages/postcss-purgecss/src/types/index.ts
@@ -26,4 +26,5 @@ export interface UserDefinedOptions {
   whitelist?: string[];
   whitelistPatterns?: Array<RegExp>;
   whitelistPatternsChildren?: Array<RegExp>;
+  whitelistPatternsGreedy?: Array<RegExp>;
 }

--- a/packages/purgecss-webpack-plugin/README.md
+++ b/packages/purgecss-webpack-plugin/README.md
@@ -157,7 +157,7 @@ new PurgecssPlugin({
 })
 ```
 
-* #### whitelist, whitelistPatterns and whitelistPatternsChildren
+* #### whitelist, whitelistPatterns, whitelistPatternsChildren, and whitelistPatternsGreedy
 
 Similar as for the `paths` option, you also can define functions for the these options:
 
@@ -176,11 +176,17 @@ function collectWhitelistPatternsChildren() {
     return [/^whitelisted-/];
 }
 
+function collectWhitelistPatternsGreedy() {
+    // do something to collect the whitelist
+    return [/^whitelisted-/];
+}
+
 // In the webpack configuration
 new PurgecssPlugin({
   whitelist: collectWhitelist,
   whitelistPatterns: collectWhitelistPatterns,
-  whitelistPatternsChildren: collectWhitelistPatternsChildren
+  whitelistPatternsChildren: collectWhitelistPatternsChildren,
+  whitelistPatternsGreedy: collectWhitelistPatternsGreedy
 })
 ```
 

--- a/packages/purgecss-webpack-plugin/__tests__/cases/path-and-whitelist-functions/webpack.config.js
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/path-and-whitelist-functions/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = {
             whitelist: () => ['whitelisted'],
             whitelistPatterns: () => [/^whitelistedPat/],
             whitelistPatternsChildren: () => [/^whitelistedPatternChildren/],
+            whitelistPatternsGreedy: () => [/^whitelistedPatternGreedy/],
             extractors: [
                 {
                     extractor: customExtractor,

--- a/packages/purgecss-webpack-plugin/src/index.ts
+++ b/packages/purgecss-webpack-plugin/src/index.ts
@@ -116,6 +116,9 @@ export default class PurgeCSSPlugin {
         if (typeof options.whitelistPatternsChildren === "function") {
           options.whitelistPatternsChildren = options.whitelistPatternsChildren();
         }
+        if (typeof options.whitelistPatternsGreedy === "function") {
+          options.whitelistPatternsGreedy = options.whitelistPatternsGreedy();
+        }
 
         const purgecss = await new PurgeCSS().purge({
           content: options.content,
@@ -130,6 +133,7 @@ export default class PurgeCSSPlugin {
           whitelist: options.whitelist,
           whitelistPatterns: options.whitelistPatterns,
           whitelistPatternsChildren: options.whitelistPatternsChildren,
+          whitelistPatternsGreedy: options.whitelistPatternsGreedy,
         });
         const purged = purgecss[0];
 

--- a/packages/purgecss-webpack-plugin/src/types/index.ts
+++ b/packages/purgecss-webpack-plugin/src/types/index.ts
@@ -31,6 +31,7 @@ export interface UserDefinedOptions {
   whitelist?: string[] | WhitelistFunction;
   whitelistPatterns?: Array<RegExp> | WhitelistPatternsFunction;
   whitelistPatternsChildren?: Array<RegExp> | WhitelistPatternsFunction;
+  whitelistPatternsGreedy?: Array<RegExp> | WhitelistPatternsFunction;
   only?: string[];
 }
 

--- a/packages/purgecss/__tests__/test_examples/whitelist_patterns_greedy/whitelist_patterns_greedy.css
+++ b/packages/purgecss/__tests__/test_examples/whitelist_patterns_greedy/whitelist_patterns_greedy.css
@@ -1,0 +1,6 @@
+.card {}
+.card[data-v-test] {}
+.card.card--large {}
+.card[data-v-test].card--large {}
+.card .card-content {}
+.card[data-v-test] .card-content {}

--- a/packages/purgecss/__tests__/test_examples/whitelist_patterns_greedy/whitelist_patterns_greedy.html
+++ b/packages/purgecss/__tests__/test_examples/whitelist_patterns_greedy/whitelist_patterns_greedy.html
@@ -1,0 +1,5 @@
+<html>
+	<body>
+		<div class="card"></div>
+	</body>
+</html>

--- a/packages/purgecss/__tests__/whitelist.test.ts
+++ b/packages/purgecss/__tests__/whitelist.test.ts
@@ -87,3 +87,41 @@ describe("whitelistPatternsChildren", () => {
     expect(purgedCSS.includes(".btn__green")).toBe(false);
   });
 });
+
+describe("whitelistPatternsGreedy", () => {
+  let purgedCSS: string;
+  beforeAll(async () => {
+    const resultsPurge = await new PurgeCSS().purge({
+      content: [
+        `${root}whitelist_patterns_greedy/whitelist_patterns_greedy.html`,
+      ],
+      css: [`${root}whitelist_patterns_greedy/whitelist_patterns_greedy.css`],
+      whitelistPatternsGreedy: [/data-v-.*/],
+    });
+    purgedCSS = resultsPurge[0].css;
+  });
+
+  it("finds card", () => {
+    expect(purgedCSS.includes(".card")).toBe(true);
+  });
+
+  it("finds card with data-v attribute", () => {
+    expect(purgedCSS.includes(".card[data-v-test]")).toBe(true);
+  });
+
+  it("excludes card--large", () => {
+    expect(purgedCSS.includes(".card.card--large")).toBe(false);
+  });
+
+  it("finds card--large with data-v attribute", () => {
+    expect(purgedCSS.includes(".card[data-v-test].card--large")).toBe(true);
+  });
+
+  it("excludes card-content", () => {
+    expect(purgedCSS.includes(".card .card-content")).toBe(false);
+  });
+
+  it("finds card-content inside card with data-v attribute", () => {
+    expect(purgedCSS.includes(".card[data-v-test] .card-content")).toBe(true);
+  });
+});

--- a/packages/purgecss/src/options.ts
+++ b/packages/purgecss/src/options.ts
@@ -15,4 +15,5 @@ export const defaultOptions: Options = {
   whitelist: [],
   whitelistPatterns: [],
   whitelistPatternsChildren: [],
+  whitelistPatternsGreedy: [],
 };

--- a/packages/purgecss/src/types/index.ts
+++ b/packages/purgecss/src/types/index.ts
@@ -55,6 +55,7 @@ export interface UserDefinedOptions {
   whitelist?: string[];
   whitelistPatterns?: Array<RegExp>;
   whitelistPatternsChildren?: Array<RegExp>;
+  whitelistPatternsGreedy?: Array<RegExp>;
 }
 
 export interface Options {
@@ -72,6 +73,7 @@ export interface Options {
   whitelist: string[];
   whitelistPatterns: Array<RegExp>;
   whitelistPatternsChildren: Array<RegExp>;
+  whitelistPatternsGreedy: Array<RegExp>;
 }
 
 export interface ResultPurge {


### PR DESCRIPTION
## Proposed changes

I am proposing a new `whitelistPatternsGreedy` option, similar to the existing `whitelistPatterns` and `whitelistPatternsChildren` options, but that whitelists an entire selector if *any part* of the selector matches the regex.

If you have a selector like this:

```css
.my-module.color--blue {}
```

And `my-module` is found by the extractor but not `color--blue`, no combination of the current `whitelistPatterns` / `whitelistPatternsChildren` exists that would prevent this selector from being purged.

With `whitelistPatternsGreedy`, you could whitelist this selector (and any other that contains the `my-module` class) like this:

```js
{
  whitelistPatternsGreedy: [/^my-module$/],
}
```

The reason I would like to add this feature is that I'm looking for a way to whitelist all scoped CSS in Vue, regardless of whether the classes are found in the HTML or not:

```vue
<template>
  <div :class="`size--${size}`"></div>
</template>

<style scoped>
  .size--small {
    font-size: 12px;
  }
  .size--large {
    font-size: 18px;
  }
</style>
```

Due to the dynamic class attribution (`size--${size}`), the `size--small` and `size--large` classes would normally be purged with the following config:

```js
{
  whitelistPatterns: [/data-v-.*/],
  defaultExtractor: (content) => {
    const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '');
    return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_:/]+/g) || [];
  },
}
```

Of course, we could opt to not remove the `<style>` blocks from the extracted content and it would also fix the issue here, but I like having that to prevent uselessly keeping Tailwind utility classes that are only used with `@apply`. So instead, we can replace `whitelistPatterns` with `whitelistPatternsGreedy` and any selector that contains a `data-v-*` attribute will be whitelisted.

Thank you!

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)