### PR TITLE
change modules property to buildModules

### DIFF
--- a/docs/guides/nuxt.md
+++ b/docs/guides/nuxt.md
@@ -26,7 +26,7 @@ to the configuration.
 
 ```js
 {
-  modules: [
+  buildModules: [ // if you are using nuxt < 2.9.0, use modules property instead.
     'nuxt-purgecss',
   ],
 


### PR DESCRIPTION
## Proposed changes

If you are using [nuxt > 2.9.0], modules property doesn't work. You should use buildModules instead.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
