### PR TITLE
chore: code typo Purgecss to PurgeCSS

### DIFF
--- a/packages/purgecss/README.md
+++ b/packages/purgecss/README.md
@@ -64,7 +64,7 @@ npm i --save-dev purgecss
 
 ```js
 import PurgeCSS from 'purgecss'
-const purgeCSSResults = await new Purgecss().purge({
+const purgeCSSResults = await new PurgeCSS().purge({
   content: ['**/*.html'],
   css: ['**/*.css']
 })


### PR DESCRIPTION
Just fix a typo in the sample code of the Readme file.