### PR TITLE
ensure v-bind and its shorthand are correctly managed with the default vue-cli-plugin-purgecss config

### DIFF
--- a/packages/vue-cli-plugin-purgecss/generator/templates/postcss.config.js
+++ b/packages/vue-cli-plugin-purgecss/generator/templates/postcss.config.js
@@ -12,7 +12,7 @@ module.exports = {
           );
           return (
             contentWithoutStyleBlocks.match(
-              /[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g
+              /[A-Za-z0-9-_/]*[A-Za-z0-9-_/]+/g
             ) || []
           );
         },


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I tried to use vue-cli-plugin-purgecss on a project with buefy (bulma wrapper for vue) and with the default generated configuration, I saw there some undetected css. I discover v-bind: shorthand are not well managed.

Example:
```javascript
      <button class="button is-success" v-on:click="start(id)" :disabled="t.disabled">Play</button>
```
In the above code, with the generated configuration, all the buefy selector that contains `button[disabled]` are dropped from the final bundle because the extracted content is ":disabled" not "disabled". With the match regex I propose, the :disabled="..." are managed as if it was disabled. The new regex makes `v-bind:disabled="..."` to be correctly managed.
