### PR TITLE
Add option blocklist to webpack plugin

### DIFF
--- a/packages/purgecss-webpack-plugin/src/index.ts
+++ b/packages/purgecss-webpack-plugin/src/index.ts
@@ -102,6 +102,10 @@ export default class PurgeCSSPlugin {
         if (typeof options.safelist === "function") {
           options.safelist = options.safelist();
         }
+        
+        if (typeof options.blocklist === "function") {
+          options.blocklist = options.blocklist();
+        }
 
         const purgecss = await new PurgeCSS().purge({
           content: options.content,
@@ -114,6 +118,7 @@ export default class PurgeCSSPlugin {
           rejected: options.rejected,
           variables: options.variables,
           safelist: options.safelist,
+          blocklist: options.blocklist,
         });
         const purged = purgecss[0];
 


### PR DESCRIPTION
## Proposed changes

`blocklist` option wasn't available for use on webpack plugin, although it's on the base purgecss code.
Solves #609 (that I've also created).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I guess this is simple enough.
