### PR TITLE
Add support for passing in promises as content

### DIFF
--- a/docs/plugins/postcss.md
+++ b/docs/plugins/postcss.md
@@ -7,7 +7,7 @@ meta:
   - itemprop: description
     content: PurgeCSS is a tool for removing CSS that you're not actually using in your project. You can use it with postcss with a plugin.
   - property: og:url
-    content:  https://purgecss.com/plugins/postcss
+    content: https://purgecss.com/plugins/postcss
   - property: og:site_name
     content: purgecss.com
   - property: og:type
@@ -40,26 +40,42 @@ npm i -D @fullhuman/postcss-purgecss postcss
 In `postcss.config.js`:
 
 ```js
-const purgecss = require('@fullhuman/postcss-purgecss')
+const purgecss = require("@fullhuman/postcss-purgecss");
 
 module.exports = {
   plugins: [
     purgecss({
-      content: ['./**/*.html']
-    })
-  ]
-}
+      content: ["./**/*.html"],
+    }),
+  ],
+};
 ```
 
 Using PostCSS API:
 
 ```js
+const purgecss = require("@fullhuman/postcss-purgecss");
+postcss([
+  purgecss({
+    content: ["./src/**/*.html"],
+  }),
+]);
+```
+
+Promises that resolve to either a `string` or `RawContent` are also supported.
+
+```js
 const purgecss = require('@fullhuman/postcss-purgecss')
 postcss([
   purgecss({
-    content: ['./src/**/*.html']
+    content: [
+      './src/**/*.html',
+
+      fetch('https://your-website/index.html').then(
+        res => res.text()
+      ),
   })
-])
+]);
 ```
 
 See [PostCSS](https://github.com/postcss/postcss) documentation for examples for your environment.
@@ -71,7 +87,7 @@ You will find below the type definition of the main options available. For the c
 
 ```ts
 export interface UserDefinedOptions {
-  content?: Array<string | RawContent>;
+  content?: Array<string | RawContent | Promise<string | RawContent>>;
   contentFunction?: (sourceFile: string) => Array<string | RawContent>;
   defaultExtractor?: ExtractorFunction;
   extractors?: Array<Extractors>;
@@ -87,12 +103,12 @@ export interface UserDefinedOptions {
 }
 
 interface RawContent {
-  extension: string
-  raw: string
+  extension: string;
+  raw: string;
 }
 
 interface RawCSS {
-  raw: string
+  raw: string;
 }
 
 type StringRegExpArray = Array<RegExp | string>;

--- a/packages/purgecss/__tests__/purgecss.config.js
+++ b/packages/purgecss/__tests__/purgecss.config.js
@@ -1,4 +1,18 @@
+import fetch from "node-fetch";
+
+const retrieveRawContentFromUrl = (url, extension) => {
+  return fetch(url)
+    .then((res) => res.text())
+    .then((text) => ({
+      raw: text,
+      extension,
+    }));
+};
+
 module.exports = {
-  content: ['index.html'],
-  css: ['style.css']
-}
+  content: [
+    "index.html",
+    retrieveRawContentFromUrl("https://github.com/FullHuman/purgecss", "html"),
+  ],
+  css: ["style.css"],
+};

--- a/packages/purgecss/src/types/index.ts
+++ b/packages/purgecss/src/types/index.ts
@@ -71,7 +71,7 @@ export interface UserDefinedOptions {
 }
 
 export interface Options {
-  content: Array<string | RawContent>;
+  content: Array<string | RawContent | Promise<string | RawContent>>;
   css: Array<string | RawCSS>;
   defaultExtractor: ExtractorFunction;
   extractors: Array<Extractors>;


### PR DESCRIPTION
## Proposed changes

Many websites add their styles, classes, etc. to their sources only through code they wrote (have local access to). They have a statically analyzable bin of files, scripts, or whatever you want to call them, that PurgeCSS is able to reason its way through which styles to remove and which to keep. This is because every CSS selector that could ever be used can be read from those same sources. 

However, this isn't always true. Some websites - like those using a CMS - could include markup coming from remote locations (i.e. a database). Their code might not reference selectors that may be included in the CMS and many will most likely be purged because of it.

Now, with that said, supporting direct database-level reading within PurgeCSS is probably a bad idea. My proposed change exposes a simple mechanism for accomplishing just that, but without the technical debt that brings: Promises.

```ts
export interface Options {
  content: Array<string | RawContent | Promise<string | RawContent>>;
  ...
}
```

Note the addition of `Promise<string | RawContent>`.

This could allow the user to pass in fetch requests, for example:

```js
import fetch from "node-fetch";

const retrieveRawContentFromUrl = (url, extension) => {
  return fetch(url)
    .then((res) => res.text())
    .then((text) => ({
      raw: text,
      extension,
    }));
};

module.exports = {
  content: [
    "index.html",
    retrieveRawContentFromUrl("https://your_website/index.html", "html"),
  ],
  css: ["style.css"],
};
```

They could go as fancy as they want. Imagine a scenario where a CMS provides an API to get raw fields from its database:

```js
const dbContent = dbContext.allItems.map(id => ({
  dbContext.getItemById(id)
    .then(dbItem =>  {
        const rawFields = dbItem.fields.join("");

        return rawFields;
    });
}));

module.exports = {
  content: dbContent,
  css: ["style.css"],
};
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I've only been using PurgeCSS for a month or so now via [TailwindCSS](https://tailwindcss.com/) and my knowledge of it is pretty limited at the moment. I spent some time looking through the codebase to figure out where to make this change, and I hope I made it in the right place. If not, or if there's a better way to accomplish this, let me know.