### PR TITLE
Fix interaction with other plugins

### DIFF
--- a/packages/postcss-purgecss/__tests__/fixtures/expected/other-plugins.css
+++ b/packages/postcss-purgecss/__tests__/fixtures/expected/other-plugins.css
@@ -1,0 +1,3 @@
+.prefixed-used-class {
+  color: black;
+}

--- a/packages/postcss-purgecss/__tests__/fixtures/src/other-plugins/other-plugins.css
+++ b/packages/postcss-purgecss/__tests__/fixtures/src/other-plugins/other-plugins.css
@@ -1,0 +1,11 @@
+.used-class {
+  color: black;
+}
+
+.unused-class {
+  color: black;
+}
+
+.another-one-not-found {
+  color: black;
+}

--- a/packages/postcss-purgecss/__tests__/fixtures/src/other-plugins/other-plugins.html
+++ b/packages/postcss-purgecss/__tests__/fixtures/src/other-plugins/other-plugins.html
@@ -1,0 +1,8 @@
+<html>
+
+  <body>
+
+    <div class="prefixed-used-class"></div>
+  </body>
+
+</html>

--- a/packages/postcss-purgecss/__tests__/index.test.ts
+++ b/packages/postcss-purgecss/__tests__/index.test.ts
@@ -93,7 +93,7 @@ describe("Purgecss postcss plugin", () => {
     const result = await postcss([
       {
         postcssPlugin: "postcss-test-prefixer",
-        Rule(rule, { Rule }) {
+        Rule(rule) {
           if (rule.selector.startsWith(".")) {
             rule.selector = ".prefixed-" + rule.selector.slice(1);
           }

--- a/packages/postcss-purgecss/__tests__/index.test.ts
+++ b/packages/postcss-purgecss/__tests__/index.test.ts
@@ -82,4 +82,31 @@ describe("Purgecss postcss plugin", () => {
         done();
       });
   });
+
+  it(`lets other plugins transform selectors before purging`, async () => {
+    const input = fs
+      .readFileSync(`${__dirname}/fixtures/src/other-plugins/other-plugins.css`)
+      .toString();
+    const expected = fs
+      .readFileSync(`${__dirname}/fixtures/expected/other-plugins.css`)
+      .toString();
+    const result = await postcss([
+      {
+        postcssPlugin: "postcss-test-prefixer",
+        Rule(rule, { Rule }) {
+          if (rule.selector.startsWith(".")) {
+            rule.selector = ".prefixed-" + rule.selector.slice(1);
+          }
+        },
+      },
+      purgeCSSPlugin({
+        content: [`${__dirname}/fixtures/src/other-plugins/other-plugins.html`],
+        fontFace: true,
+        keyframes: true,
+      }),
+    ]).process(input, { from: undefined });
+
+    expect(result.css).toBe(expected);
+    expect(result.warnings().length).toBe(0);
+  });
 });

--- a/packages/postcss-purgecss/src/index.ts
+++ b/packages/postcss-purgecss/src/index.ts
@@ -77,7 +77,7 @@ const purgeCSSPlugin: postcss.PluginCreator<UserDefinedOptions> = function (
     throw new Error("PurgeCSS plugin does not have the correct options");
   return {
     postcssPlugin: PLUGIN_NAME,
-    Once(root, helpers) {
+    OnceExit(root, helpers) {
       return purgeCSS(opts, root, helpers);
     },
   };


### PR DESCRIPTION
## Proposed changes

Currently, PurgeCSS purges at the beginning of tree traversal. If you use other plugins that transform selectors, PurgeCSS purges them before the other plugins had a chance to transform them.

One example where this fails is the following interaction with [postcss-nested](https://github.com/postcss/postcss-nested):
```
.selector {
    &:hover {
    }
}
```
PurgeCSS gets rid of `&:hover` before `postcss-nested` can transform it to `.selector:hover`, which would have been kept.

This PR changes the behavior so that PurgeCSS purges _after_ all other transformations have been applied.

## Types of changes

What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

