### PR TITLE
fix purgecss-from-pug not handle class attributes with multiple values correctly #677

### DIFF
--- a/packages/purgecss-from-pug/__tests__/data.ts
+++ b/packages/purgecss-from-pug/__tests__/data.ts
@@ -6,6 +6,7 @@ html
     div(class="test-container") Well
     div(class="test-footer" id="an-id") I see a div
     a(class="a-link" id="a-link" href="#") and a link
+    div(class="first-class second-class") This div has two classes
     input#blo.enabled(type="text" disabled)
 `;
 
@@ -23,6 +24,8 @@ export const TEST_1_CLASS = [
   "test-container",
   "test-footer",
   "a-link",
+  "first-class",
+  "second-class",
   "enabled",
 ];
 

--- a/packages/purgecss-from-pug/src/index.ts
+++ b/packages/purgecss-from-pug/src/index.ts
@@ -8,12 +8,12 @@ const purgeFromPug = (content: string): string[] => {
       case "tag":
       case "id":
       case "class":
-        selectors.push(token.val);
+        selectors.push(...token.val.split(" "));
         break;
       case "attribute":
         if (token.name === "class" || token.name === "id") {
           selectors.push(
-            token.mustEscape ? token.val.replace(/"/g, "") : token.val
+            ...(token.mustEscape ? token.val.replace(/"/g, "") : token.val).split(" ")
           );
         }
         break;


### PR DESCRIPTION
## Proposed changes

Replace `token.val` in purgecss-from-pug by `...token.val.split(" ")` as done in purgecss-from-html to correctly handle class attributes with multiple values.

```diff
      case "tag":
      case "id":
      case "class":
-       selectors.push(token.val);
+       selectors.push(...token.val.split(" "));
        break;
      case "attribute":
        if (token.name === "class" || token.name === "id") {
          selectors.push(
-           token.mustEscape ? token.val.replace(/"/g, "") : token.val
+           ...(token.mustEscape ? token.val.replace(/"/g, "") : token.val).split(" ")
          );
        }
        break;
```

Also complete the unittest for purgecss-from-pug to demonstrate that multiple classes are correctly handled.

See bug [#677](https://github.com/FullHuman/purgecss/issues/677)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I am fairly new to purgecss, but clearly all CSS classes are not correctly extracted from .pug files and this is related to purgecss-from-pug treating a class attribute with multiple values as a single value as shown in the bug report. When checking the difference with purgecss-from-html, we can see that purgecss-from-pug extract classes with `token.val` while purgecss-from-html do something like `val.split(" ")`.
