### PR TITLE
fix: Allow Absolute Paths

### DIFF
--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -63,7 +63,7 @@ export async function setOptions(
 ): Promise<Options> {
   let options: Options;
   try {
-    const t = path.join(process.cwd(), configFile);
+    const t = path.resolve(process.cwd(), configFile);
     options = await import(t);
   } catch (err) {
     throw new Error(`${ERROR_CONFIG_FILE_LOADING} ${err.message}`);


### PR DESCRIPTION
Currently PurgeCSS only allows relative config path.
For example,
```shell
purgecss --config  abc/purgecss.config.js
```

This will allow absolute paths such as 
```shell
purgecss --config /Users/subash/Desktop/Test/purgecss.config.js
```

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
