### PR TITLE
Add optional name for RawCSS option

### DIFF
--- a/packages/purgecss/__tests__/raw-css-name.test.ts
+++ b/packages/purgecss/__tests__/raw-css-name.test.ts
@@ -1,0 +1,39 @@
+import PurgeCSS from "../src/index";
+
+describe("Raw CSS optional filename", () => {
+  it("Should return the `name` in the result's `file` property when provided for raw CSS option", async () => {
+    return new PurgeCSS()
+      .purge({
+        content: [
+          { raw: "<html><body><h1></h1></body></html>", extension: "html" },
+        ],
+        css: [
+          { raw: "body{margin:0;}", name: "test.css" },
+          { raw: "h1{margin:1;}" },
+        ],
+      })
+      .then((results) => {
+        expect(results.length).toBe(2);
+        expect(
+          results.some((result) => {
+            return result.file && result.file.endsWith("test.css");
+          })
+        ).toBe(true);
+        results.forEach((result) => expect(typeof result.css).toBe("string"));
+      });
+  });
+  it("Should NOT return the `name` in the result's `file` property when NOT provided for raw CSS option", async () => {
+    return new PurgeCSS()
+      .purge({
+        content: [
+          { raw: "<html><body><h1></h1></body></html>", extension: "html" },
+        ],
+        css: [{ raw: "body{margin:0;}" }],
+      })
+      .then((results) => {
+        expect(results.length).toBe(1);
+        expect(results[0].file).toBe(undefined);
+        results.forEach((result) => expect(typeof result.css).toBe("string"));
+      });
+  });
+});

--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -542,12 +542,8 @@ class PurgeCSS {
 
       const result: ResultPurge = {
         css: root.toString(),
-        file: typeof option === "string" ? option : undefined,
+        file: typeof option === "string" ? option : option.name,
       };
-
-      if (typeof option === "string") {
-        result.file = option;
-      }
 
       if (this.options.rejected) {
         result.rejected = Array.from(this.selectorsRemoved);

--- a/packages/purgecss/src/types/index.ts
+++ b/packages/purgecss/src/types/index.ts
@@ -16,6 +16,7 @@ export interface RawContent<T = string> {
 
 export interface RawCSS {
   raw: string;
+  name?: string;
 }
 
 export interface ExtractorResultDetailed {


### PR DESCRIPTION
## Proposed changes
Added an optional `name` property to RawCSS option to be used (instead of using `undefined`) when creating the result's `file` property.

At the moment the result returns `undefined` for the `file` property when using the RawCSS option, adding an identifier name would be great to differentiate between the result of multiple RawCSS data.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Test for this feature is included.