### PR TITLE
fix rejected css output generation

### DIFF
--- a/packages/purgecss/__tests__/rejectedCss.test.ts
+++ b/packages/purgecss/__tests__/rejectedCss.test.ts
@@ -32,7 +32,7 @@ describe("rejectedCss", () => {
       css: [`${ROOT_TEST_EXAMPLES}rejectedCss/empty-parent-node.css`],
       rejectedCss: true,
     });
-    const expectedRejectedCss = `@media (max-width: 66666px) {\n  .unused-class {\n    color: black;\n  }\n}`;
+    const expectedRejectedCss = `@media (max-width: 66666px) {\n   .unused-class {\n    color: black;\n  }\n}`;
     const expectedPurgedCss = `@media (max-width: 66666px) {\n  .used-class {\n    color: black;\n  }\n}`;
     expect(resultsPurge[0].rejectedCss?.trim()).toEqual(expectedRejectedCss);
     expect(resultsPurge[0].css.trim()).toEqual(expectedPurgedCss);

--- a/packages/purgecss/__tests__/rejectedCss.test.ts
+++ b/packages/purgecss/__tests__/rejectedCss.test.ts
@@ -9,10 +9,7 @@ describe("rejectedCss", () => {
       css: [`${ROOT_TEST_EXAMPLES}rejectedCss/simple.css`],
       rejectedCss: true,
     });
-    const expected = `
-.rejected {
-    color: blue;
-}`;
+    const expected = `.rejected {\n  color: blue;\n}`;
     expect(resultsPurge[0].rejectedCss?.trim()).toBe(expected.trim());
   });
   it("contains the rejected selectors as part of the rejected css", async () => {
@@ -28,14 +25,16 @@ describe("rejectedCss", () => {
   /**
    * https://github.com/FullHuman/purgecss/pull/763#discussion_r754618902
    */
-  it("preserves the node correctly when having an empty parent node", async () => {
-    expect.assertions(1);
+  it("preserves the node correctly", async () => {
+    expect.assertions(2);
     const resultsPurge = await new PurgeCSS().purge({
       content: [`${ROOT_TEST_EXAMPLES}rejectedCss/empty-parent-node.js`],
       css: [`${ROOT_TEST_EXAMPLES}rejectedCss/empty-parent-node.css`],
       rejectedCss: true,
     });
-    const expected = `@media (max-width: 66666px) {\n  .unused-class, .unused-class2 {\n    color: black;\n  }\n}`;
-    expect(resultsPurge[0].rejectedCss?.trim()).toEqual(expected);
+    const expectedRejectedCss = `@media (max-width: 66666px) {\n  .unused-class {\n    color: black;\n  }\n}`;
+    const expectedPurgedCss = `@media (max-width: 66666px) {\n  .used-class {\n    color: black;\n  }\n}`;
+    expect(resultsPurge[0].rejectedCss?.trim()).toEqual(expectedRejectedCss);
+    expect(resultsPurge[0].css.trim()).toEqual(expectedPurgedCss);
   });
 });

--- a/packages/purgecss/__tests__/test_examples/rejectedCss/empty-parent-node.css
+++ b/packages/purgecss/__tests__/test_examples/rejectedCss/empty-parent-node.css
@@ -1,5 +1,5 @@
 @media (max-width: 66666px) {
-  .unused-class, .unused-class2 {
+  .used-class, .unused-class {
     color: black;
   }
 }

--- a/packages/purgecss/__tests__/test_examples/rejectedCss/empty-parent-node.js
+++ b/packages/purgecss/__tests__/test_examples/rejectedCss/empty-parent-node.js
@@ -1,0 +1,1 @@
+"used-class"

--- a/packages/purgecss/__tests__/test_examples/rejectedCss/simple.css
+++ b/packages/purgecss/__tests__/test_examples/rejectedCss/simple.css
@@ -1,7 +1,7 @@
 .critical {
-    color: red;
+  color: red;
 }
 
 .rejected {
-    color: blue;
+  color: blue;
 }

--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -457,7 +457,7 @@ class PurgeCSS {
     }
 
     let keepSelector = true;
-    const originalSelector = node.selector;
+    const selectorsRemovedFromRule: string[] = [];
     node.selector = selectorParser((selectorsParsed) => {
       selectorsParsed.walk((selector) => {
         if (selector.type !== "selector") {
@@ -469,6 +469,9 @@ class PurgeCSS {
         if (!keepSelector) {
           if (this.options.rejected) {
             this.selectorsRemoved.add(selector.toString());
+          }
+          if (this.options.rejectedCss) {
+            selectorsRemovedFromRule.push(selector.toString());
           }
           selector.remove();
         }
@@ -487,18 +490,19 @@ class PurgeCSS {
     const parent = node.parent;
     if (!node.selector) {
       node.remove();
-      if (this.options.rejectedCss) {
-        node.selector = originalSelector;
-        if (parent && isRuleEmpty(parent)) {
-          const clone = parent.clone();
-          clone.append(node);
-          this.removedNodes.push(clone);
-        } else {
-          this.removedNodes.push(node);
-        }
-      }
     }
     if (isRuleEmpty(parent)) parent?.remove();
+
+    // rebuild the rule with the removed selectors and optionally its parent 
+    if (this.options.rejectedCss) {
+      if (selectorsRemovedFromRule.length > 0) {
+        const clone = node.clone();
+        const parentClone = parent?.clone().removeAll().append(clone);
+        clone.selectors = selectorsRemovedFromRule;
+        const nodeToPreserve = parentClone ? parentClone : clone;
+        this.removedNodes.push(nodeToPreserve);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

Fix the output generation of rejected CSS

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is the remaining commit for #763 .

Copy from the comment there:

I added the following test case:
```css
@media (max-width: 66666px) {
  .used-class, .unused-class {
    color: black;
  }
}
```
Which I was handling incorrectly.
What the rejected css 'algorithm' now does is:

- keep track of what selectors are removed from the rule
- if any selector is removed from the rule, clone the rule (or its parent if there exists one)
- replace the (deemed critical) selectors from the clone with the rejected selectors
- preserve that rule node as rejectedCss output
So the above case would result in:
```css
/* critical */
@media (max-width: 66666px) {
  .used-class {
    color: black;
  }
}
/* rejected */
@media (max-width: 66666px) {
  .unused-class {
    color: black;
  }
}
```
Purging the css is easier since you walk down the AST nodes and remove what you don't need. Keeping the rejected css is harder since once you have a node you need to preserve you then also have to preserve its ancestors to get the correct output.

Can you think of any examples where a rule node is nested more that just 1 parent deep? My understanding is that these are CSS nodes thus the selectors are flattened, but if there is a case like:
```css
@media (min-width: 1px) {
  @media (max-width: 200px) {
    .selector {
      color: black;
    }
  }
}
```
I would have to add something that goes up the tree to preserve the correcct output