### PR TITLE
Recover reject css with webpack plugin

### DIFF
--- a/packages/purgecss-webpack-plugin/README.md
+++ b/packages/purgecss-webpack-plugin/README.md
@@ -136,6 +136,10 @@ new PurgeCSSPlugin({
 
 If `true` all removed selectors are added to the [Stats Data](https://webpack.js.org/api/stats/) as `purged`.
 
+* #### rejectedCss
+
+If `true` generate another output file based on output name containing rejected css.<br> For an entry point named `foo`, the purged file will be named `foo.css` and the rejected one `foo-rejected.css`  
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](./../../CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/packages/purgecss-webpack-plugin/README.md
+++ b/packages/purgecss-webpack-plugin/README.md
@@ -138,7 +138,20 @@ If `true` all removed selectors are added to the [Stats Data](https://webpack.js
 
 * #### rejectedCss
 
-If `true` generate another output file based on output name containing rejected css.<br> For an entry point named `foo`, the purged file will be named `foo.css` and the rejected one `foo-rejected.css`  
+```ts
+// Output the rejected css as `[base]-rejected.[ext]`
+new PurgeCSSPlugin({
+  rejectedCss: true,
+});
+
+// or use a custom output path
+new PurgeCSSPlugin({
+  rejectedCss: '[base].rejected.css',
+});
+```
+Generate an output file containing the rejected css.  
+If the value is a string it will be used as a Webpack [template string](https://webpack.js.org/configuration/output/#template-strings) to generate the filename.
+If `true` the template path will default to `[base]-rejected.[ext]`. So for an entry point named `foo`, the purged file will be named `foo.css` and the rejected one `foo-rejected.css`  
 
 ## Contributing
 

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/expected/styles.rejected.css
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/expected/styles.rejected.css
@@ -1,0 +1,5 @@
+
+
+.rejected {
+  color: blue;
+}

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/src/content.html
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/src/content.html
@@ -1,0 +1,11 @@
+<html>
+
+<head>
+  <title>Purgecss webpack test</title>
+</head>
+
+<body>
+  <div class="preserved"></div>
+</body>
+
+</html>

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/src/index.js
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/src/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/src/style.css
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/src/style.css
@@ -1,0 +1,8 @@
+
+.preserved {
+  color: red;
+}
+
+.rejected {
+  color: blue;
+}

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/webpack.config.js
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css-template-name/webpack.config.js
@@ -1,0 +1,44 @@
+const path = require("path");
+const glob = require("glob");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const PurgecssPlugin = require("../../../src").default;
+
+const PATHS = {
+  src: path.join(__dirname, "src"),
+};
+
+module.exports = {
+  mode: "development",
+  entry: "./src/index.js",
+  context: path.resolve(__dirname),
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          name: "styles",
+          type: "css/mini-extract",
+          test: /\.css$/,
+          chunks: "all",
+          enforce: true,
+        },
+      },
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+    ],
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+    new PurgecssPlugin({
+      paths: () => glob.sync(`${PATHS.src}/*`),
+      rejectedCss: "[base].rejected.css",
+    }),
+  ],
+};

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/expected/styles-rejected.css
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/expected/styles-rejected.css
@@ -1,0 +1,5 @@
+
+
+.rejected {
+  color: blue;
+}

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/content.html
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/content.html
@@ -1,0 +1,11 @@
+<html>
+
+<head>
+  <title>Purgecss webpack test</title>
+</head>
+
+<body>
+  <div class="preserved"></div>
+</body>
+
+</html>

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/index.js
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/style.css
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/src/style.css
@@ -1,0 +1,8 @@
+
+.preserved {
+  color: red;
+}
+
+.rejected {
+  color: blue;
+}

--- a/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/webpack.config.js
+++ b/packages/purgecss-webpack-plugin/__tests__/cases/rejected-css/webpack.config.js
@@ -1,0 +1,44 @@
+const path = require("path");
+const glob = require("glob");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const PurgecssPlugin = require("../../../src").default;
+
+const PATHS = {
+  src: path.join(__dirname, "src"),
+};
+
+module.exports = {
+  mode: "development",
+  entry: "./src/index.js",
+  context: path.resolve(__dirname),
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        styles: {
+          name: "styles",
+          type: "css/mini-extract",
+          test: /\.css$/,
+          chunks: "all",
+          enforce: true,
+        },
+      },
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+    ],
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+    new PurgecssPlugin({
+      paths: () => glob.sync(`${PATHS.src}/*`),
+      rejectedCss: true,
+    }),
+  ],
+};

--- a/packages/purgecss-webpack-plugin/__tests__/index.test.ts
+++ b/packages/purgecss-webpack-plugin/__tests__/index.test.ts
@@ -38,6 +38,8 @@ describe("Webpack integration", () => {
     "path-and-safelist-functions",
     "simple",
     "simple-with-exclusion",
+    "rejected-css",
+    "rejected-css-template-name",
   ];
 
   for (const testCase of cases) {

--- a/packages/purgecss-webpack-plugin/src/index.ts
+++ b/packages/purgecss-webpack-plugin/src/index.ts
@@ -115,7 +115,7 @@ export default class PurgeCSSPlugin {
           keyframes: options.keyframes,
           output: options.output,
           rejected: options.rejected,
-          rejectedCss: options.rejectedCss,
+          rejectedCss: !!options.rejectedCss,
           variables: options.variables,
           safelist: options.safelist,
           blocklist: options.blocklist,
@@ -128,15 +128,22 @@ export default class PurgeCSSPlugin {
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        let source: Source = new ConcatSource(purged.css)
-        compilation.updateAsset(name, source);
+        compilation.updateAsset(name, new ConcatSource(purged.css));
         if (purged.rejectedCss !== undefined) {
-          source = new ConcatSource(purged.rejectedCss)
-          const rejectedName: string = path.dirname(name) + '/' + path.basename(name, '.css') + '-rejected' + path.extname(name)
+          const rejectedCssSource = new ConcatSource(purged.rejectedCss);
+          const rejectedNameTemplate = typeof options.rejectedCss === "string" ? options.rejectedCss : "[base]-rejected.[ext]";
+          const rejectedName = compilation.getPath(rejectedNameTemplate, {
+            basename: path.basename(name, path.extname(name)),
+            filename: name,
+          });
           if (compilation.getAsset(rejectedName) === undefined) {
-            compilation.emitAsset(rejectedName, source);
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            compilation.emitAsset(rejectedName, rejectedCssSource);
           } else {
-            compilation.updateAsset(rejectedName, source);
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            compilation.updateAsset(rejectedName, rejectedCssSource);
           }
         }
       }

--- a/packages/purgecss-webpack-plugin/src/index.ts
+++ b/packages/purgecss-webpack-plugin/src/index.ts
@@ -115,6 +115,7 @@ export default class PurgeCSSPlugin {
           keyframes: options.keyframes,
           output: options.output,
           rejected: options.rejected,
+          rejectedCss : options.rejectedCss,
           variables: options.variables,
           safelist: options.safelist,
           blocklist: options.blocklist,

--- a/packages/purgecss-webpack-plugin/src/index.ts
+++ b/packages/purgecss-webpack-plugin/src/index.ts
@@ -1,9 +1,9 @@
 import * as fs from "fs";
 import path from "path";
-import PurgeCSS, { defaultOptions } from "purgecss";
-import { Compilation, Compiler } from "webpack";
-import { ConcatSource } from "webpack-sources";
-import { PurgedStats, UserDefinedOptions } from "./types";
+import PurgeCSS, {defaultOptions} from "purgecss";
+import {Compilation, Compiler} from "webpack";
+import {ConcatSource} from "webpack-sources";
+import {PurgedStats, UserDefinedOptions} from "./types";
 
 const styleExtensions = [".css", ".scss", ".styl", ".sass", ".less"];
 const pluginName = "PurgeCSS";
@@ -13,10 +13,10 @@ const pluginName = "PurgeCSS";
  * @param fileName file name
  */
 function getFormattedFilename(fileName: string): string {
-  if (fileName.includes("?")) {
-    return fileName.split("?").slice(0, -1).join("");
-  }
-  return fileName;
+    if (fileName.includes("?")) {
+        return fileName.split("?").slice(0, -1).join("");
+    }
+    return fileName;
 }
 
 /**
@@ -25,111 +25,121 @@ function getFormattedFilename(fileName: string): string {
  * @param extensions extensions
  */
 function isFileOfTypes(filename: string, extensions: string[]): boolean {
-  const extension = path.extname(getFormattedFilename(filename));
-  return extensions.includes(extension);
+    const extension = path.extname(getFormattedFilename(filename));
+    return extensions.includes(extension);
 }
 
 export default class PurgeCSSPlugin {
-  options: UserDefinedOptions;
-  purgedStats: PurgedStats = {};
+    options: UserDefinedOptions;
+    purgedStats: PurgedStats = {};
 
-  constructor(options: UserDefinedOptions) {
-    this.options = options;
-  }
+    constructor(options: UserDefinedOptions) {
+        this.options = options;
+    }
 
-  apply(compiler: Compiler): void {
-    compiler.hooks.compilation.tap(
-      pluginName,
-      this.initializePlugin.bind(this)
-    );
-  }
+    apply(compiler: Compiler): void {
+        compiler.hooks.compilation.tap(
+            pluginName,
+            this.initializePlugin.bind(this)
+        );
+    }
 
-  initializePlugin(compilation: Compilation): void {
-    compilation.hooks.additionalAssets.tapPromise(pluginName, () => {
-      const entryPaths =
-        typeof this.options.paths === "function"
-          ? this.options.paths()
-          : this.options.paths;
+    initializePlugin(compilation: Compilation): void {
+        compilation.hooks.additionalAssets.tapPromise(pluginName, () => {
+            const entryPaths =
+                typeof this.options.paths === "function"
+                    ? this.options.paths()
+                    : this.options.paths;
 
-      entryPaths.forEach((p) => {
-        if (!fs.existsSync(p)) throw new Error(`Path ${p} does not exist.`);
-      });
+            entryPaths.forEach((p) => {
+                if (!fs.existsSync(p)) throw new Error(`Path ${p} does not exist.`);
+            });
 
-      return this.runPluginHook(compilation, entryPaths);
-    });
-  }
+            return this.runPluginHook(compilation, entryPaths);
+        });
+    }
 
-  async runPluginHook(
-    compilation: Compilation,
-    entryPaths: string[]
-  ): Promise<void> {
-    const assetsFromCompilation = Object.entries(compilation.assets).filter(
-      ([name]) => {
-        return isFileOfTypes(name, [".css"]);
-      }
-    );
-
-    for (const chunk of compilation.chunks) {
-      const assetsToPurge = assetsFromCompilation.filter(([name]) => {
-        if (this.options.only) {
-          return this.options.only.some((only) => name.includes(only));
-        }
-
-        return Array.isArray(chunk.files)
-          ? chunk.files.includes(name)
-          : chunk.files.has(name);
-      });
-
-      for (const [name, asset] of assetsToPurge) {
-        const filesToSearch = entryPaths.filter(
-          (v) => !styleExtensions.some((ext) => v.endsWith(ext))
+    async runPluginHook(
+        compilation: Compilation,
+        entryPaths: string[]
+    ): Promise<void> {
+        const assetsFromCompilation = Object.entries(compilation.assets).filter(
+            ([name]) => {
+                return isFileOfTypes(name, [".css"]);
+            }
         );
 
-        // Compile through Purgecss and attach to output.
-        // This loses sourcemaps should there be any!
-        const options = {
-          ...defaultOptions,
-          ...this.options,
-          content: filesToSearch,
-          css: [
-            {
-              raw: asset.source().toString(),
-            },
-          ],
-        };
+        for (const chunk of compilation.chunks) {
+            const assetsToPurge = assetsFromCompilation.filter(([name]) => {
+                if (this.options.only) {
+                    return this.options.only.some((only) => name.includes(only));
+                }
 
-        if (typeof options.safelist === "function") {
-          options.safelist = options.safelist();
+                return Array.isArray(chunk.files)
+                    ? chunk.files.includes(name)
+                    : chunk.files.has(name);
+            });
+
+            for (const [name, asset] of assetsToPurge) {
+                const filesToSearch = entryPaths.filter(
+                    (v) => !styleExtensions.some((ext) => v.endsWith(ext))
+                );
+
+                // Compile through Purgecss and attach to output.
+                // This loses sourcemaps should there be any!
+                const options = {
+                    ...defaultOptions,
+                    ...this.options,
+                    content: filesToSearch,
+                    css: [
+                        {
+                            raw: asset.source().toString(),
+                        },
+                    ],
+                };
+
+                if (typeof options.safelist === "function") {
+                    options.safelist = options.safelist();
+                }
+
+                if (typeof options.blocklist === "function") {
+                    options.blocklist = options.blocklist();
+                }
+
+                const purgecss = await new PurgeCSS().purge({
+                    content: options.content,
+                    css: options.css,
+                    defaultExtractor: options.defaultExtractor,
+                    extractors: options.extractors,
+                    fontFace: options.fontFace,
+                    keyframes: options.keyframes,
+                    output: options.output,
+                    rejected: options.rejected,
+                    rejectedCss: options.rejectedCss,
+                    variables: options.variables,
+                    safelist: options.safelist,
+                    blocklist: options.blocklist,
+                });
+                const purged = purgecss[0];
+                if (purged.rejected) {
+                    this.purgedStats[name] = purged.rejected;
+                }
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                let source: Source = new ConcatSource(purged.css)
+                compilation.updateAsset(name, source);
+                if (purged.rejectedCss !== undefined) {
+                    source = new ConcatSource(purged.rejectedCss)
+                    let rejectedName : string = name.replace('.css','-rejected.css')
+                    if(compilation.getAsset(rejectedName) === undefined){
+                        compilation.emitAsset(rejectedName, source);
+                    }else{
+                        compilation.updateAsset(rejectedName, source);
+                    }
+
+
+                }
+            }
         }
-
-        if (typeof options.blocklist === "function") {
-          options.blocklist = options.blocklist();
-        }
-
-        const purgecss = await new PurgeCSS().purge({
-          content: options.content,
-          css: options.css,
-          defaultExtractor: options.defaultExtractor,
-          extractors: options.extractors,
-          fontFace: options.fontFace,
-          keyframes: options.keyframes,
-          output: options.output,
-          rejected: options.rejected,
-          rejectedCss : options.rejectedCss,
-          variables: options.variables,
-          safelist: options.safelist,
-          blocklist: options.blocklist,
-        });
-        const purged = purgecss[0];
-
-        if (purged.rejected) {
-          this.purgedStats[name] = purged.rejected;
-        }
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        compilation.updateAsset(name, new ConcatSource(purged.css));
-      }
     }
-  }
 }

--- a/packages/purgecss-webpack-plugin/src/index.ts
+++ b/packages/purgecss-webpack-plugin/src/index.ts
@@ -1,9 +1,9 @@
 import * as fs from "fs";
 import path from "path";
-import PurgeCSS, {defaultOptions} from "purgecss";
-import {Compilation, Compiler} from "webpack";
-import {ConcatSource} from "webpack-sources";
-import {PurgedStats, UserDefinedOptions} from "./types";
+import PurgeCSS, { defaultOptions } from "purgecss";
+import { Compilation, Compiler } from "webpack";
+import { ConcatSource } from "webpack-sources";
+import { PurgedStats, UserDefinedOptions } from "./types";
 
 const styleExtensions = [".css", ".scss", ".styl", ".sass", ".less"];
 const pluginName = "PurgeCSS";
@@ -13,10 +13,10 @@ const pluginName = "PurgeCSS";
  * @param fileName file name
  */
 function getFormattedFilename(fileName: string): string {
-    if (fileName.includes("?")) {
-        return fileName.split("?").slice(0, -1).join("");
-    }
-    return fileName;
+  if (fileName.includes("?")) {
+    return fileName.split("?").slice(0, -1).join("");
+  }
+  return fileName;
 }
 
 /**
@@ -25,121 +25,121 @@ function getFormattedFilename(fileName: string): string {
  * @param extensions extensions
  */
 function isFileOfTypes(filename: string, extensions: string[]): boolean {
-    const extension = path.extname(getFormattedFilename(filename));
-    return extensions.includes(extension);
+  const extension = path.extname(getFormattedFilename(filename));
+  return extensions.includes(extension);
 }
 
 export default class PurgeCSSPlugin {
-    options: UserDefinedOptions;
-    purgedStats: PurgedStats = {};
+  options: UserDefinedOptions;
+  purgedStats: PurgedStats = {};
 
-    constructor(options: UserDefinedOptions) {
-        this.options = options;
-    }
+  constructor(options: UserDefinedOptions) {
+    this.options = options;
+  }
 
-    apply(compiler: Compiler): void {
-        compiler.hooks.compilation.tap(
-            pluginName,
-            this.initializePlugin.bind(this)
-        );
-    }
+  apply(compiler: Compiler): void {
+    compiler.hooks.compilation.tap(
+      pluginName,
+      this.initializePlugin.bind(this)
+    );
+  }
 
-    initializePlugin(compilation: Compilation): void {
-        compilation.hooks.additionalAssets.tapPromise(pluginName, () => {
-            const entryPaths =
-                typeof this.options.paths === "function"
-                    ? this.options.paths()
-                    : this.options.paths;
+  initializePlugin(compilation: Compilation): void {
+    compilation.hooks.additionalAssets.tapPromise(pluginName, () => {
+      const entryPaths =
+        typeof this.options.paths === "function"
+          ? this.options.paths()
+          : this.options.paths;
 
-            entryPaths.forEach((p) => {
-                if (!fs.existsSync(p)) throw new Error(`Path ${p} does not exist.`);
-            });
+      entryPaths.forEach((p) => {
+        if (!fs.existsSync(p)) throw new Error(`Path ${p} does not exist.`);
+      });
 
-            return this.runPluginHook(compilation, entryPaths);
-        });
-    }
+      return this.runPluginHook(compilation, entryPaths);
+    });
+  }
 
-    async runPluginHook(
-        compilation: Compilation,
-        entryPaths: string[]
-    ): Promise<void> {
-        const assetsFromCompilation = Object.entries(compilation.assets).filter(
-            ([name]) => {
-                return isFileOfTypes(name, [".css"]);
-            }
-        );
+  async runPluginHook(
+    compilation: Compilation,
+    entryPaths: string[]
+  ): Promise<void> {
+    const assetsFromCompilation = Object.entries(compilation.assets).filter(
+      ([name]) => {
+        return isFileOfTypes(name, [".css"]);
+      }
+    );
 
-        for (const chunk of compilation.chunks) {
-            const assetsToPurge = assetsFromCompilation.filter(([name]) => {
-                if (this.options.only) {
-                    return this.options.only.some((only) => name.includes(only));
-                }
-
-                return Array.isArray(chunk.files)
-                    ? chunk.files.includes(name)
-                    : chunk.files.has(name);
-            });
-
-            for (const [name, asset] of assetsToPurge) {
-                const filesToSearch = entryPaths.filter(
-                    (v) => !styleExtensions.some((ext) => v.endsWith(ext))
-                );
-
-                // Compile through Purgecss and attach to output.
-                // This loses sourcemaps should there be any!
-                const options = {
-                    ...defaultOptions,
-                    ...this.options,
-                    content: filesToSearch,
-                    css: [
-                        {
-                            raw: asset.source().toString(),
-                        },
-                    ],
-                };
-
-                if (typeof options.safelist === "function") {
-                    options.safelist = options.safelist();
-                }
-
-                if (typeof options.blocklist === "function") {
-                    options.blocklist = options.blocklist();
-                }
-
-                const purgecss = await new PurgeCSS().purge({
-                    content: options.content,
-                    css: options.css,
-                    defaultExtractor: options.defaultExtractor,
-                    extractors: options.extractors,
-                    fontFace: options.fontFace,
-                    keyframes: options.keyframes,
-                    output: options.output,
-                    rejected: options.rejected,
-                    rejectedCss: options.rejectedCss,
-                    variables: options.variables,
-                    safelist: options.safelist,
-                    blocklist: options.blocklist,
-                });
-                const purged = purgecss[0];
-                if (purged.rejected) {
-                    this.purgedStats[name] = purged.rejected;
-                }
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                let source: Source = new ConcatSource(purged.css)
-                compilation.updateAsset(name, source);
-                if (purged.rejectedCss !== undefined) {
-                    source = new ConcatSource(purged.rejectedCss)
-                    let rejectedName : string = name.replace('.css','-rejected.css')
-                    if(compilation.getAsset(rejectedName) === undefined){
-                        compilation.emitAsset(rejectedName, source);
-                    }else{
-                        compilation.updateAsset(rejectedName, source);
-                    }
-
-
-                }
-            }
+    for (const chunk of compilation.chunks) {
+      const assetsToPurge = assetsFromCompilation.filter(([name]) => {
+        if (this.options.only) {
+          return this.options.only.some((only) => name.includes(only));
         }
+
+        return Array.isArray(chunk.files)
+          ? chunk.files.includes(name)
+          : chunk.files.has(name);
+      });
+
+      for (const [name, asset] of assetsToPurge) {
+        const filesToSearch = entryPaths.filter(
+          (v) => !styleExtensions.some((ext) => v.endsWith(ext))
+        );
+
+        // Compile through Purgecss and attach to output.
+        // This loses sourcemaps should there be any!
+        const options = {
+          ...defaultOptions,
+          ...this.options,
+          content: filesToSearch,
+          css: [
+            {
+              raw: asset.source().toString(),
+            },
+          ],
+        };
+
+        if (typeof options.safelist === "function") {
+          options.safelist = options.safelist();
+        }
+
+        if (typeof options.blocklist === "function") {
+          options.blocklist = options.blocklist();
+        }
+
+        const purgecss = await new PurgeCSS().purge({
+          content: options.content,
+          css: options.css,
+          defaultExtractor: options.defaultExtractor,
+          extractors: options.extractors,
+          fontFace: options.fontFace,
+          keyframes: options.keyframes,
+          output: options.output,
+          rejected: options.rejected,
+          rejectedCss: options.rejectedCss,
+          variables: options.variables,
+          safelist: options.safelist,
+          blocklist: options.blocklist,
+        });
+        const purged = purgecss[0];
+
+        if (purged.rejected) {
+          this.purgedStats[name] = purged.rejected;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        let source: Source = new ConcatSource(purged.css)
+        compilation.updateAsset(name, source);
+        if (purged.rejectedCss !== undefined) {
+          source = new ConcatSource(purged.rejectedCss)
+          const rejectedName: string = path.dirname(name) + '/' + path.basename(name, '.css') + '-rejected' + path.extname(name)
+          if (compilation.getAsset(rejectedName) === undefined) {
+            compilation.emitAsset(rejectedName, source);
+          } else {
+            compilation.updateAsset(rejectedName, source);
+          }
+        }
+      }
     }
+  }
 }

--- a/packages/purgecss-webpack-plugin/src/types/index.ts
+++ b/packages/purgecss-webpack-plugin/src/types/index.ts
@@ -29,6 +29,7 @@ export interface UserDefinedOptions {
   moduleExtensions?: string[];
   output?: string;
   rejected?: boolean;
+  rejectedCss?: boolean | string;
   stdin?: boolean;
   stdout?: boolean;
   variables?: boolean;


### PR DESCRIPTION
## Proposed changes

Recover purged css in separete css file for webpack plugin.

see #816 and #763.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

First time for me and my coworker (@Firologame) working on a public repo. Also discovering how webpack plugin work and first contact with typescript. We don't know how to create tests, but our developement didn't create any error on the existing tests. Please be gentle !

Feel free to upgrade those few changes and give us feedback, thank you for your attention !
