### PR TITLE
fix(purgecss-webpack-plugin): export as named export as well as default

### DIFF
--- a/packages/purgecss-webpack-plugin/src/index.ts
+++ b/packages/purgecss-webpack-plugin/src/index.ts
@@ -29,7 +29,7 @@ function isFileOfTypes(filename: string, extensions: string[]): boolean {
   return extensions.includes(extension);
 }
 
-export default class PurgeCSSPlugin {
+export class PurgeCSSPlugin {
   options: UserDefinedOptions;
   purgedStats: PurgedStats = {};
 
@@ -132,3 +132,5 @@ export default class PurgeCSSPlugin {
     }
   }
 }
+
+export default PurgeCSSPlugin;


### PR DESCRIPTION
## Proposed changes

This should provide a workaround for #820 by enabling importing the class via it's name as well as by default.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

While the types are still wrong, I think fixing them might be a heavy task as it depends on what is actually building the types & doing the packages - I'm happy to try help with that, but that requires having the whole project setup locally; this workaround will unblock people in the meantime.
