### PR TITLE
fix(purgecss): Add options for CSS_SAFELIST

### DIFF
--- a/packages/purgecss/src/internal-safelist.ts
+++ b/packages/purgecss/src/internal-safelist.ts
@@ -1,1 +1,1 @@
-export const CSS_SAFELIST = ["*", ":root", ":after", ":before"];
+export const CSS_SAFELIST = ["*", ":root", ":after", ":before", "body", "html"];


### PR DESCRIPTION
Add options for CSS_SAFELIST to fix styles of `html` and `body` being removed incorrectly when using webPack packaging.

## Proposed changes
fix #824 
When using webpack to package a project, the `body` and `html` tags are in the HTML template, so the `purgecss-webpack-plugin` mistakenly removes the styles of `html` and `body` defined in the `.css` file. So add options for CSS_SAFELIST to fix this problem.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
