### PR TITLE
Update hugo.md

### DIFF
--- a/docs/guides/hugo.md
+++ b/docs/guides/hugo.md
@@ -93,14 +93,17 @@ See the [PurgeCSS configuration docs](../configuration.md) for details on each o
 In the HTML Template for your `<head>`, add this:
 
 ```html
-{{ $css := resources.Get "css/style.css" | resources.PostCSS }} {{ if
-hugo.IsProduction }} {{ $css = $css | minify | fingerprint |
-resources.PostProcess }} {{ end }}
+{{ $css := resources.Get "css/style.css" | resources.PostCSS }} 
+{{ if hugo.IsProduction }} 
+    {{ $css = $css | minify | fingerprint | resources.PostProcess }} 
+{{ end }}
 
 <link
   rel="stylesheet"
   href="{{ $css.RelPermalink }}"
-  integrity="{{ $css.Data.Integrity }}"
+  {{ if hugo.IsProduction -}} 
+    integrity="{{ $css.Data.Integrity }}"
+  {{- end }}
 />
 ```
 


### PR DESCRIPTION
The proposed template to add a style tag in the Hugo integration doc will work only on production runs. 

The `$css.Data.Integrity` variable exists only if `fingerprint` was run on the CSS. So wrapping it in a `hugo.IsProduction` check is required for the attribute to not fail a `hugo` run on development or other environments.