### PR TITLE
Fix wrong import name

### DIFF
--- a/docs/plugins/webpack.md
+++ b/docs/plugins/webpack.md
@@ -42,7 +42,7 @@ npm i purgecss-webpack-plugin -D
 const path = require("path");
 const glob = require("glob");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const { PurgecssPlugin } = require("purgecss-webpack-plugin");
+const { PurgeCSSPlugin } = require("purgecss-webpack-plugin");
 
 const PATHS = {
   src: path.join(__dirname, "src"),
@@ -78,7 +78,7 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: "[name].css",
     }),
-    new PurgecssPlugin({
+    new PurgeCSSPlugin({
       paths: glob.sync(`${PATHS.src}/**/*`, { nodir: true }),
     }),
   ],
@@ -90,7 +90,7 @@ module.exports = {
 If you need multiple paths use the npm package `glob-all` instead of `glob`, then you can use this syntax:
 
 ```js
-new PurgecssPlugin({
+new PurgeCSSPlugin({
   paths: glob.sync([
     // ...
   ])
@@ -110,14 +110,14 @@ With the webpack plugin, you can specify the content that should be analyzed by 
 > You likely need to pass `{ noDir: true }` as an option to `glob.sync()` as `glob.sync` is matching a dir which the plugin can't operate on.
 
 ```js
-const { PurgecssPlugin } = require("purgecss-webpack-plugin");
+const { PurgeCSSPlugin } = require("purgecss-webpack-plugin");
 const glob = require("glob");
 const PATHS = {
   src: path.join(__dirname, "src"),
 };
 
 // In the webpack configuration
-new PurgecssPlugin({
+new PurgeCSSPlugin({
   paths: glob.sync(`${PATHS.src}/**/*`, { nodir: true }),
 });
 ```
@@ -125,7 +125,7 @@ new PurgecssPlugin({
 If you want to regenerate the list of paths on every compilation (e.g. when using `--watch`), then you can also pass a function to the `paths` option as in the following example:
 
 ```js
-new PurgecssPlugin({
+new PurgeCSSPlugin({
   paths: () => glob.sync(`${PATHS.src}/**/*`, { nodir: true }),
 });
 ```
@@ -135,7 +135,7 @@ new PurgecssPlugin({
 You can specify chunk names to the purgecss-webpack-plugin with the option `only`:
 
 ```js
-new PurgecssPlugin({
+new PurgeCSSPlugin({
   paths: glob.sync(`${PATHS.src}/**/*`, { nodir: true }),
   only: ["bundle", "vendor"],
 });


### PR DESCRIPTION
## Proposed changes

Fixing import name. Because in the module `purgess-webpack-plugin`, the name export have been changed to `PurgeCSSPlugin`.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I have a small project with webpack, i want to use something which can remove some unused css (from bootstrap). And i found purgecss, i tried it and its look good. I checked the documentation and found this module can use with webpack (`purgess-webpack-plugin`).

So i follow the documentation for integrate with webpack, and when i build. I always got error `TypeError: PurgecssPlugin is not a constructor`.

I googled all for the solution but nothing work. And then i try to find this module in node_modules and search for the export name `PurgecssPlugin`, the name is no result. And i found the name have been changed to `PurgeCSSPlugin`.

Well, after that i use that import name and then the webpack build is running normally.

