### PR TITLE
Point to new extractor package names

### DIFF
--- a/docs/extractors.md
+++ b/docs/extractors.md
@@ -38,7 +38,7 @@ The default extractor considers every word of a file as a selector. The default 
 
 Using an extractor can be useful if you notice that PurgeCSS does not remove enough unused css or removes used ones.
 
-Using a specific extractor for an extension should provide you with the best accuracy. If you want to purge exclusively html files you might want to consider the `purge-from-html` extractor.
+Using a specific extractor for an extension should provide you with the best accuracy. If you want to purge exclusively html files you might want to consider the `purgecss-from-html` extractor.
 
 You can use an extractor by settings the extractors option in the PurgeCSS config file.
 
@@ -65,7 +65,7 @@ export default options
 
 ## Creating an extractor
 
-An extractor is a simple function that takes the content of a file as a string and returns an array of selectors. By convention, the name of the npm package is `purge-from-[typefile]` \(e.g. purge-from-pug\). Using this convention will allow users to look at the list of extractor on npm by searching `purge-from`.
+An extractor is a simple function that takes the content of a file as a string and returns an array of selectors. By convention, the name of the npm package is `purgecss-from-[typefile]` \(e.g. purgecss-from-pug\). Using this convention will allow users to look at the list of extractor on npm by searching `purgecss-from`.
 
 ```js
 const purgeFromJs = (content) => {


### PR DESCRIPTION
## Proposed changes

I noticed that the docs on extractors refer to `purge-from-*` package names. While they are still available, the naming schema seems to have changed to `purcecss-from-*`. I thought it would be a quick little change to reflect this in the docs.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

