### PR TITLE
Styles like font-family should be kept and not purged when any individual selector is used within a group selector

### DIFF
--- a/packages/purgecss/__tests__/font-faces.test.ts
+++ b/packages/purgecss/__tests__/font-faces.test.ts
@@ -21,6 +21,11 @@ describe("purge unused font-face", () => {
       purgedCSS.includes(`src: url('../fonts/CerebriSans-Regular.eot?')`)
     ).toBe(true);
   });
+  it("keep @font-face 'Cerebri Italic'", () => {
+    expect(
+      purgedCSS.includes(`src: url('../fonts/CerebriSans-Italic.eot?')`)
+    ).toBe(true);
+  });
   it("remove @font-face 'OtherFont'", () => {
     expect(purgedCSS.includes(`src: url('xxx')`)).toBe(false);
   });

--- a/packages/purgecss/__tests__/test_examples/font-faces/font_face.css
+++ b/packages/purgecss/__tests__/test_examples/font-faces/font_face.css
@@ -23,7 +23,7 @@
     color: black;
 }
 
-.used {
+.used1 {
     color: red;
     font-family: 'Cerebri Sans';
 }
@@ -31,4 +31,10 @@
 .used2 {
   color: blue;
   font-family: Cerebri Bold, serif;
+}
+
+.used3,
+.unused1 {
+  color: green;
+  font-family: OtherFont, serif;
 }

--- a/packages/purgecss/__tests__/test_examples/font-faces/font_face.css
+++ b/packages/purgecss/__tests__/test_examples/font-faces/font_face.css
@@ -23,7 +23,7 @@
     color: black;
 }
 
-.used1 {
+.used {
     color: red;
     font-family: 'Cerebri Sans';
 }

--- a/packages/purgecss/__tests__/test_examples/font-faces/font_face.css
+++ b/packages/purgecss/__tests__/test_examples/font-faces/font_face.css
@@ -13,6 +13,13 @@
 }
 
 @font-face {
+    font-family: 'Cerebri Italic';
+    font-weight: 400;
+    font-style: normal;
+    src: url('../fonts/CerebriSans-Italic.eot?') format('eot'), url('../fonts/CerebriSans-Italic.otf') format('opentype'), url('../fonts/CerebriSans-Italic.svg#Cerebri_Sans') format('svg'), url('../fonts/CerebriSans-Italic.ttf') format('truetype'), url('../fonts/CerebriSans-Italic.woff') format('woff');
+}
+
+@font-face {
     font-family: 'OtherFont';
     font-weight: 400;
     font-style: normal;
@@ -28,13 +35,13 @@
     font-family: 'Cerebri Sans';
 }
 
+.used1,
+.unused {
+  color: green;
+  font-family: 'Cerebri Italic';
+}
+
 .used2 {
   color: blue;
   font-family: Cerebri Bold, serif;
-}
-
-.used3,
-.unused1 {
-  color: green;
-  font-family: OtherFont, serif;
 }

--- a/packages/purgecss/__tests__/test_examples/font-faces/font_face.html
+++ b/packages/purgecss/__tests__/test_examples/font-faces/font_face.html
@@ -3,6 +3,7 @@
 <body>
     <div class="used"></div>
     <div class="used2"></div>
+    <div class="used3"></div>
 </body>
 
 </html>

--- a/packages/purgecss/__tests__/test_examples/font-faces/font_face.html
+++ b/packages/purgecss/__tests__/test_examples/font-faces/font_face.html
@@ -2,8 +2,8 @@
 
 <body>
     <div class="used"></div>
+    <div class="used1"></div>
     <div class="used2"></div>
-    <div class="used3"></div>
 </body>
 
 </html>

--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -858,6 +858,28 @@ class PurgeCSS {
         return false;
       }
 
+      // The selector's parent is present and contains a comma
+      if (selector.parent && selector.parent.toString().indexOf(',') > -1) {
+        for (const parent of selector.parent.toString().split(',')) {
+          const parentSelector = parent.trim().replace(".", "");
+          // Handle cases where css is joined with a comma
+          switch (selectorNode.type) {
+            case "class":
+              if (selectorsFromExtractor.hasClass(parentSelector)) {
+                return true;
+              }
+              break;
+            case "id":
+              if (selectorsFromExtractor.hasId(parentSelector)) {
+                return true;
+              }
+              break;
+            default:
+              continue;
+            }
+          }
+        }
+
       switch (selectorNode.type) {
         case "attribute":
           // `value` is a dynamic attribute, highly used in input element


### PR DESCRIPTION
## Proposed changes

When CSS classes are defined together, and an earlier rule is used, but a later one is not, then it is purged when it should not.

e.g.

```css
.used,
.unused {
@font-family(should keep)
}
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

In addition to the failed test, I also added some code to make the tests pass. Inside of `shouldKeepSelector` I check to see if the parent has a comma and then see if any of the classes are in use. If they are, it will return true so that things like font family and other CSS elements in that block are kept. Without the fix, if the last CSS selector is unused, it does not bring in the font family and so the style will fail when rendered.