### PR TITLE
Add alignwide and alignfull classes from GB

### DIFF
--- a/packages/purgecss-with-wordpress/index.js
+++ b/packages/purgecss-with-wordpress/index.js
@@ -14,6 +14,8 @@ module.exports = {
     "alignnone",
     "alignright",
     "alignleft",
+    "alignwide",
+    "alignfull",
     "wp-caption",
     "wp-caption-text",
     "screen-reader-text",


### PR DESCRIPTION
Gutenberg blocks use these classes.