### PR TITLE
Fix [class*=foo] with HTML extractor

### DIFF
--- a/packages/purgecss-from-html/__tests__/data.ts
+++ b/packages/purgecss-from-html/__tests__/data.ts
@@ -27,6 +27,11 @@ export const TEST_1_CLASS = ["test-container", "test-footer", "a-link"];
 
 export const TEST_1_ID = ["a-link", "blo"];
 
+export const TEST_1_ATTRIBUTES = {
+    NAMES: ["href", "id", "class", "type", "disabled"],
+    VALUES: ["#", "a-link", "a-link", "text", ...TEST_1_CLASS, ...TEST_1_ID]
+}
+
 export const TEST_2_CONTENT = `
 <template>
     <div id="app">

--- a/packages/purgecss-from-html/__tests__/index.test.ts
+++ b/packages/purgecss-from-html/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import purgehtml from "./../src/index";
 
-import { TEST_1_CONTENT, TEST_1_TAG, TEST_1_CLASS, TEST_1_ID } from "./data";
+import { TEST_1_CONTENT, TEST_1_TAG, TEST_1_CLASS, TEST_1_ID, TEST_1_ATTRIBUTES } from "./data";
 import { TEST_2_CONTENT, TEST_2_TAG, TEST_2_CLASS, TEST_2_ID } from "./data";
 
 describe("purgehtml", () => {
@@ -22,6 +22,18 @@ describe("purgehtml", () => {
     it("finds id selectors", () => {
       for (const item of TEST_1_ID) {
         expect(resultTest1.ids.includes(item)).toBe(true);
+      }
+    });
+
+    it("finds attributes names", () => {
+      for (const item of TEST_1_ATTRIBUTES.NAMES) {
+        expect(resultTest1.attributes.names.includes(item)).toBe(true);
+      }
+    });
+
+    it("finds attributes values", () => {
+      for (const item of TEST_1_ATTRIBUTES.VALUES) {
+        expect(resultTest1.attributes.values.includes(item)).toBe(true);
       }
     });
   });

--- a/packages/purgecss-from-html/src/index.ts
+++ b/packages/purgecss-from-html/src/index.ts
@@ -53,10 +53,10 @@ const getSelectorsInElement = (
       result.classes.push(...value.split(" "));
     } else if (name === "id") {
       result.ids.push(...value.split(" "));
-    } else {
-      result.attributes.names.push(name);
-      result.attributes.values.push(...value.split(" "));
     }
+    // always add to attributes, to handle things like [class*=foo]
+    result.attributes.names.push(name);
+    result.attributes.values.push(...value.split(" "));
   }
 
   return mergedExtractorResults(getSelectorsInNodes(element), result);

--- a/packages/purgecss/__tests__/attributes.test.ts
+++ b/packages/purgecss/__tests__/attributes.test.ts
@@ -1,7 +1,20 @@
 import { PurgeCSS } from "./../src/index";
 import { ROOT_TEST_EXAMPLES } from "./utils";
+import purgecssFromHtml from "purgecss-from-html";
 
-describe("attributes", () => {
+// we run this  suite against both the default and HTML extractors, as the HTML
+// extractor's more granular attribute handling can cause bugs
+describe.each([
+  [[]],
+  [
+    [
+      {
+        extensions: ["html"],
+        extractor: purgecssFromHtml,
+      },
+    ],
+  ],
+])("attributes", (extractors) => {
   let purgedCSS: string;
 
   beforeAll(async () => {
@@ -9,6 +22,7 @@ describe("attributes", () => {
       content: [`${ROOT_TEST_EXAMPLES}attributes/attribute_selector.html`],
       css: [`${ROOT_TEST_EXAMPLES}attributes/attribute_selector.css`],
       dynamicAttributes: ["aria-selected"],
+      extractors
     });
     purgedCSS = resultsPurge[0].css;
   });


### PR DESCRIPTION
## Proposed changes

Previously, the values of the id and class attributes were stored only as ids and classes respectively, which meant selectors like [class*=foo] were spuriously removed because "foo" is only treated as a class value, not an attribute value. This PR fixes that by unconditionally adding attributes to the generic attribute list, then also adding them to the id/class lists if appropriate.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
  - Some unrelated tests are failing with include errors - I suspect I've done something wrong with Lerna on my machine and it's unrelated, but let's see what CI says.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
  - N/A
