### PR TITLE
bugfix: Classes that contain `:is` or `:where` in their names are no longer unintentionally purged

### DIFF
--- a/packages/purgecss/__tests__/pseudo-class.test.ts
+++ b/packages/purgecss/__tests__/pseudo-class.test.ts
@@ -107,6 +107,9 @@ describe(":where pseudo class", () => {
     const resultsPurge = await new PurgeCSS().purge({
       content: [`${ROOT_TEST_EXAMPLES}pseudo-class/where.html`],
       css: [`${ROOT_TEST_EXAMPLES}pseudo-class/where.css`],
+      safelist: {
+        standard: ["[&:where(.a)]:text-black"],
+      }
     });
     purgedCSS = resultsPurge[0].css;
   });
@@ -115,6 +118,7 @@ describe(":where pseudo class", () => {
     expect(purgedCSS.includes(".unused")).toBe(false);
     expect(purgedCSS.includes(".root :where(.a) .c {")).toBe(true);
     expect(purgedCSS.includes(".root:where(.a) .c {")).toBe(true);
+    expect(purgedCSS.includes(".\\[\\&\\:where\\(\\.a\\)\\]\\:text-black:where(.a) {")).toBe(true);
   });
 });
 
@@ -124,6 +128,9 @@ describe(":is pseudo class", () => {
     const resultsPurge = await new PurgeCSS().purge({
       content: [`${ROOT_TEST_EXAMPLES}pseudo-class/is.html`],
       css: [`${ROOT_TEST_EXAMPLES}pseudo-class/is.css`],
+      safelist: {
+        standard: ["[&:is(.a)]:text-black"]
+      }
     });
     purgedCSS = resultsPurge[0].css;
   });
@@ -132,5 +139,6 @@ describe(":is pseudo class", () => {
     expect(purgedCSS.includes(".unused")).toBe(false);
     expect(purgedCSS.includes(".root :is(.a) .c {")).toBe(true);
     expect(purgedCSS.includes(".root:is(.a) .c {")).toBe(true);
+    expect(purgedCSS.includes(".\\[\\&\\:is\\(\\.a\\)\\]\\:text-black:is(.a) {")).toBe(true);
   });
 });

--- a/packages/purgecss/__tests__/test_examples/pseudo-class/is.css
+++ b/packages/purgecss/__tests__/test_examples/pseudo-class/is.css
@@ -22,3 +22,7 @@
 .root :is(.a, .b) .c :is(.unused, .unused2) {
   display: flex;
 }
+
+.\[\&\:is\(\.a\)\]\:text-black:is(.a) {
+  color: black;
+}

--- a/packages/purgecss/__tests__/test_examples/pseudo-class/where.css
+++ b/packages/purgecss/__tests__/test_examples/pseudo-class/where.css
@@ -22,3 +22,7 @@
 .root :where(.a, .b) .c :where(.unused, .unused2) {
   display: flex;
 }
+
+.\[\&\:where\(\.a\)\]\:text-black:where(.a) {
+  color: black;
+}

--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -553,6 +553,7 @@ class PurgeCSS {
         }
       });
 
+      // removes selectors containing empty :where and :is
       selectorsParsed.walk((selector) => {
         if (selector.type !== "selector") {
           return;
@@ -560,9 +561,15 @@ class PurgeCSS {
 
         if (
           selector.toString() &&
-          /(:where$)|(:is$)|(:where[^(])|(:is[^(])/.test(selector.toString())
+          /(:where)|(:is)/.test(selector.toString())
         ) {
-          selector.remove();
+          selector.walk((node) => {
+            if (node.type !== "pseudo") return;
+            if (node.value !== ":where" && node.value !== ":is") return;
+            if (node.nodes.length === 0) {
+              selector.remove();
+            }
+          });
         }
       });
     }).processSync(node.selector);


### PR DESCRIPTION
## Proposed changes

Class selectors that contained `:is` or `:where` within their names were being unintentionally purged. The use-case that brought about this issue was using these pseudo-classes in tailwind (e.g. `class="[&:where(.some-class)]:text-black"`), which would generate the following CSS:
```css
.\[\&\:where\(\.some-class\)\]\:text-black:where(.some-class) {
	color: black;
}
```

This regex will misfire for the class above and for any classes that contain `:where` or `:is` in their names (even when the class name is added to the safelist!):
```js
if ( selector.toString() && /(:where$)|(:is$)|(:where[^(])|(:is[^(])/.test(selector.toString()) ) {
	selector.remove();
}
```

As such, I added the appropriate tests, slightly widened the regex and added a more rigorous check for if the functional pseudo-class is empty of selectors:
```ts
if ( selector.toString() && /(:where)|(:is)/.test(selector.toString()) ) {
	selector.walk((node) => {
		if (node.type !== "pseudo") return;
		if (node.value !== ":where" && node.value !== ":is") return;
		if (node.nodes.length === 0) {
		  selector.remove();
		}
	});
}
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
