### PR TITLE
bugfix: Only throw `No files found from the passed PurgeCSS option 'content'.` warning when files/globs are passed to `content`

### DIFF
--- a/packages/purgecss/__tests__/index.test.ts
+++ b/packages/purgecss/__tests__/index.test.ts
@@ -117,4 +117,15 @@ describe("Warn if no files are found from the option 'content'", () => {
     console.warn = originalConsoleWarn;
   });
 
+  it("does not warn if raw content is found", async () => {
+    const originalConsoleWarn = console.warn;
+    console.warn = jest.fn();
+    await new PurgeCSS().purge({
+      content: [{ raw: '<div class="a">test</div>', extension: 'html' }],
+      css: [`${ROOT_TEST_EXAMPLES}others/remove_unused.css`]
+    });
+    expect(console.warn).not.toHaveBeenCalled();
+    console.warn = originalConsoleWarn;
+  });
+
 })

--- a/packages/purgecss/src/index.ts
+++ b/packages/purgecss/src/index.ts
@@ -427,7 +427,7 @@ class PurgeCSS {
         }));
       }
     }
-    if (filesNames.length === 0) {
+    if (files.length > 0 && filesNames.length === 0) {
       console.warn("No files found from the passed PurgeCSS option 'content'.")
     }
     for (const file of filesNames) {


### PR DESCRIPTION
## Proposed changes

Fixes #1104

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
