### PR TITLE
docs: replace remaining `purgecss` by `purgeCSSPlugin`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,7 +46,7 @@ import { purgeCSSPlugin } from '@fullhuman/postcss-purgecss';
 
 module.exports = {
   plugins: [
-    purgecss({
+    purgeCSSPlugin({
       content: ['./**/*.html']
     })
   ]

--- a/packages/postcss-purgecss/README.md
+++ b/packages/postcss-purgecss/README.md
@@ -18,9 +18,9 @@ npm i -D @fullhuman/postcss-purgecss postcss
 ## Usage
 
 ```js
-const purgecss = require('@fullhuman/postcss-purgecss')
+const { purgeCSSPlugin } = require('@fullhuman/postcss-purgecss')
 postcss([
-  purgecss({
+  purgeCSSPlugin({
     content: ['./src/**/*.html']
   })
 ])


### PR DESCRIPTION
## Proposed changes

This PR proposes two minor documentation updates to reflect recent changes regarding the use of `purgeCSSPlugin`. Additionally, it addresses any potential oversights where `purgecss` was still referenced instead of `purgeCSSPlugin`.

The modification to `docs/getting-started.md` appeared straightforward, especially when compared to similar changes we've made in the past. Specifically, we're not utilizing the imported item in this case.

For the update to `packages/postcss-purgecss/README.md`, I tested the approach locally. However, since I'm not an advanced user of PurgeCSS, there may be nuances I've missed, so I'm open to feedback on this part.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Documentation fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
  - Note: there was a linting issue but apparently not linked to my modifications since I replicate in the `main`branch
  
  ```sh
  /Users/ju/purgecss/docs/.vuepress/.cache/deps/@vue_devtools-api.js
  3901:5  error  Definition for rule 'es5/no-es6-methods' was not found  es5/no-es6-methods
  ```
- (N/A) I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

N/A
