### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/packages/vue-cli-plugin-purgecss/generator/templates/postcss.config.js
+++ b/packages/vue-cli-plugin-purgecss/generator/templates/postcss.config.js
@@ -6,10 +6,15 @@ module.exports = {
       require("@fullhuman/postcss-purgecss")({
         content: [`./public/**/*.html`, `./src/**/*.vue`],
         defaultExtractor(content) {
-          const contentWithoutStyleBlocks = content.replace(
-            /<style[^]+?<\/style>/gi,
-            ""
-          );
+          let previous;
+          let contentWithoutStyleBlocks = content;
+          do {
+            previous = contentWithoutStyleBlocks;
+            contentWithoutStyleBlocks = contentWithoutStyleBlocks.replace(
+              /<style[^]+?<\/style>/gi,
+              ""
+            );
+          } while (contentWithoutStyleBlocks !== previous);
           return (
             contentWithoutStyleBlocks.match(
               /[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g


### PR DESCRIPTION
Potential fix for [https://github.com/FullHuman/purgecss/security/code-scanning/5](https://github.com/FullHuman/purgecss/security/code-scanning/5)

To fix the problem, we need to ensure that all instances of `<style>` tags and their content are removed from the input string, even if they are nested or malformed. The best way to achieve this is to apply the regular expression replacement repeatedly until no more replacements can be performed. This ensures that all instances are effectively removed.

**Steps to fix:**
1. Modify the `defaultExtractor` function to repeatedly apply the regular expression replacement until no more replacements occur.
2. Ensure that the function returns the sanitized content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
